### PR TITLE
Add thousand separator to scanned number on detail card

### DIFF
--- a/ui/src/components/DetailListCard.svelte
+++ b/ui/src/components/DetailListCard.svelte
@@ -6,9 +6,11 @@
   import formatDistanceToNow from "date-fns/formatDistanceToNow";
   import { format } from "date-fns";
   import { printTimeDiff } from "../utils/utils";
-  import { Navigate, navigateTo } from "svelte-router-spa";
-  import ArtilleryDetailTable from "./ArtilleryDetailTable.svelte";
+  import { navigateTo } from "svelte-router-spa";
   export let value = {};
+  function numberWithCommas(x) {
+    return x.toLocaleString()
+  }
 </script>
 
 <style>
@@ -67,7 +69,7 @@
           </span>
           <br />
           <span class="font-sans text-base pt-2">
-            Scanned: {val.totalScanned} items
+            Scanned: {numberWithCommas(val.totalScanned)} items
           </span>
         </div>
 


### PR DESCRIPTION
<img width="1264" alt="image" src="https://user-images.githubusercontent.com/67776356/112234778-58080800-8c91-11eb-8e6a-04b8f991726b.png">

**Figure: Thousand separator to scanned number on the left column**