### PR TITLE
Make Rule labels more human readable

### DIFF
--- a/docker/api.js
+++ b/docker/api.js
@@ -72,8 +72,8 @@ exports.getHTMLHintRules = (api, url) => {
 };
 
 exports.htmlHintConfig = {
-  "Common Agile Scrum Terms people get wrong": true,
-  "Code block - missing language": true,
+  "grammar-scrum-terms": true,
+  "code-block-missing-language": true,
   "tagname-lowercase": true,
   "attr-lowercase": true,
   "attr-value-double-quotes": true,

--- a/docker/customHtmlRules.js
+++ b/docker/customHtmlRules.js
@@ -3,7 +3,7 @@ const HTMLHint = require("htmlhint").default;
 exports.addCustomHtmlRule = () => {
     // Custom rule to find code block with no language specifier
     HTMLHint.addRule({
-        id: "Code block - missing language",
+        id: "code-block-missing-language",
         description: "Code blocks must contain a language specifier.",
         init: function (parser, reporter) {
           var self = this;
@@ -31,7 +31,7 @@ exports.addCustomHtmlRule = () => {
       });
 
       HTMLHint.addRule({
-        id: "Common Agile Scrum Terms people get wrong",
+        id: "grammar-scrum-terms",
         description: "Checks case of common Agile Scrum terms that people get wrong.",
         init: function (parser, reporter) {
           var self = this;

--- a/ui/src/components/htmlhintcomponents/HtmlErrorsByReason.svelte
+++ b/ui/src/components/htmlhintcomponents/HtmlErrorsByReason.svelte
@@ -7,7 +7,8 @@
     getCodeErrorRules,
     getHtmlHintIssues,
     getCodeErrorsByRule,
-    HTMLERRORS
+    HTMLERRORS,
+    getRuleLink,    
   } from "../../utils/utils.js";
   import { fade, fly } from "svelte/transition";
   import { ignoredUrls$ } from "../../stores.js";
@@ -86,7 +87,7 @@
     <a
       class="inline align-baseline text-blue-600 hover:text-blue-800"
       target="_blank"
-      href={htmlHintIssues.indexOf(error.error) >= 0 ? `https://htmlhint.com/docs/user-guide/rules/${error.error}` : `https://sswcodingstandards.web.app//rules/${error.error}`}>
+      href={getRuleLink(error.error)}>
       {error.error}
     </a>
   </div>

--- a/ui/src/components/htmlhintcomponents/HtmlErrorsByReason.svelte
+++ b/ui/src/components/htmlhintcomponents/HtmlErrorsByReason.svelte
@@ -8,7 +8,7 @@
     getHtmlHintIssues,
     getCodeErrorsByRule,
     HTMLERRORS,
-    getRuleLink,    
+    getRuleLink,
   } from "../../utils/utils.js";
   import { fade, fly } from "svelte/transition";
   import { ignoredUrls$ } from "../../stores.js";

--- a/ui/src/components/htmlhintcomponents/HtmlErrorsByReason.svelte
+++ b/ui/src/components/htmlhintcomponents/HtmlErrorsByReason.svelte
@@ -9,6 +9,7 @@
     getCodeErrorsByRule,
     HTMLERRORS,
     getRuleLink,
+    getDisplayText,
   } from "../../utils/utils.js";
   import { fade, fly } from "svelte/transition";
   import { ignoredUrls$ } from "../../stores.js";
@@ -88,7 +89,7 @@
       class="inline align-baseline text-blue-600 hover:text-blue-800"
       target="_blank"
       href={getRuleLink(error.error)}>
-      {error.error}
+      {getDisplayText(error.error)}
     </a>
   </div>
   {#if showHide && !hiddenRows[error.error]}

--- a/ui/src/components/htmlhintcomponents/HtmlErrorsBySource.svelte
+++ b/ui/src/components/htmlhintcomponents/HtmlErrorsBySource.svelte
@@ -7,6 +7,7 @@
     getCodeErrorRules,
     getCodeErrorsByFile,
     getRuleLink,
+    getDisplayText,
   } from "../../utils/utils.js";
   import { fade } from "svelte/transition";
   import { createEventDispatcher } from "svelte";
@@ -103,7 +104,7 @@
                 class="inline-block align-baseline link"
                 target="_blank"
                 href={getRuleLink(key)}>
-                {key}
+                {getDisplayText(key)}
               </a>
 
             </td>

--- a/ui/src/components/htmlhintcomponents/HtmlErrorsBySource.svelte
+++ b/ui/src/components/htmlhintcomponents/HtmlErrorsBySource.svelte
@@ -5,7 +5,8 @@
     HTMLERRORS,
     getHtmlHintIssues,
     getCodeErrorRules,
-    getCodeErrorsByFile
+    getCodeErrorsByFile,
+    getRuleLink,
   } from "../../utils/utils.js";
   import { fade } from "svelte/transition";
   import { createEventDispatcher } from "svelte";
@@ -101,7 +102,7 @@
               <a
                 class="inline-block align-baseline link"
                 target="_blank"
-                href={htmlHintIssues.indexOf(key) >= 0 ? `https://htmlhint.com/docs/user-guide/rules/${key}` : `https://sswcodingstandards.web.app//rules/${key}`}>
+                href={getRuleLink(key)}>
                 {key}
               </a>
 

--- a/ui/src/components/htmlhintcomponents/UpdateHTMLRules.svelte
+++ b/ui/src/components/htmlhintcomponents/UpdateHTMLRules.svelte
@@ -66,7 +66,7 @@
           <a 
           class="text-blue-700" 
           href="https://htmlhint.com/docs/user-guide/rules/{rule.rule}">
-            {rule.rule}
+            {rule.displayName}
           </a>
       </label>
     {/each}
@@ -76,8 +76,9 @@
       <label>
         <input type="checkbox" bind:group={selection} value={rule.rule} /> 
           <a 
-          class="text-black-700" >
-            {rule.rule}
+          class="text-black-700" 
+          href={rule.ruleLink}>
+            {rule.displayName}
           </a>
       </label>
     {/each}

--- a/ui/src/containers/Rules.svelte
+++ b/ui/src/containers/Rules.svelte
@@ -24,9 +24,9 @@
             <td>Code blocks must contain a language specifier.</td>
           </tr>
           <tr>
-            <td>Common Agile Scrum Terms people get wrong</td>
-            <td><a href="https://www.ssw.com.au/rules/scrum-should-be-capitalized">Scrum should be capitalized</a></td>
-            <td>Pages that reference Agile Scrum must have correct case for Scrum terminology.</td>
+            <td>Grammar mistake - common Scrum terms</td>
+            <td><a href="https://www.ssw.com.au/rules/scrum-should-be-capitalized">Grammar - Do you know "Scrum" should be capitalized</a></td>
+            <td>References to "Agile Scrum" must be capitalized as "Scrum".</td>
           </tr>
         </table>
       </div>

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -322,7 +322,7 @@ export const getRuleLink = (errorKey) => {
 export const getDisplayText = (errorKey) => {
   if (customHtmlHintRules.some(item => item.rule === errorKey)) {
     var customRule = customHtmlHintRules.find(item => item.rule == errorKey);
-    return customRule.displayName != "" ? htmlHint.displayName : htmlHint.rule;
+    return customRule.displayName != "" ? customRule.displayName : customRule.rule;
   }
   else if (htmlHintRules.some(item => item.rule == errorKey)){
     var htmlHint = htmlHintRules.find(item => item.rule == errorKey);

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -309,6 +309,16 @@ export const getHtmlHintIssues = pipe(
 	uniq
 );
 
+export const getRuleLink = (errorKey) => {
+  if (customHtmlHintRules.some(rule => rule.rule === errorKey)) {
+    var custom = customHtmlHintRules.find(item => item.rule == errorKey);
+    return custom.ruleLink;
+  }
+  else {
+    return `https://htmlhint.com/docs/user-guide/rules/${errorKey}`;
+  }
+};
+
 export const htmlHintRules = [
 	{ rule: "tagname-lowercase" },
 	{ rule: "attr-lowercase" }, 
@@ -335,7 +345,7 @@ export const htmlHintRules = [
  ];
 
  export const customHtmlHintRules = [
-	{ rule: "Code block - missing language" },
-  { rule: "Common Agile Scrum Terms people get wrong" },
+	{ rule: "Code block - missing language", ruleLink: "https://www.ssw.com.au/rules/set-language-on-code-blocks" },
+  { rule: "Common Agile Scrum Terms people get wrong", ruleLink: "https://www.ssw.com.au/rules/scrum-should-be-capitalized" },
 	// Add new rule id below
  ];

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -320,13 +320,17 @@ export const getRuleLink = (errorKey) => {
 };
 
 export const getDisplayText = (errorKey) => {
-  if (customHtmlHintRules.some(rule => rule.rule === errorKey)) {
-    return errorKey;
+  if (customHtmlHintRules.some(item => item.rule === errorKey)) {
+    var customRule = customHtmlHintRules.find(item => item.rule == errorKey);
+    return customRule.displayName != "" ? htmlHint.displayName : htmlHint.rule;
   }
-  else {
+  else if (htmlHintRules.some(item => item.rule == errorKey)){
     var htmlHint = htmlHintRules.find(item => item.rule == errorKey);
     return htmlHint.displayName != "" ? htmlHint.displayName : htmlHint.rule;
-  } 
+  }
+  else {
+    return errorKey;
+  }
 };
 
 export const htmlHintRules = [
@@ -354,7 +358,7 @@ export const htmlHintRules = [
  ];
 
  export const customHtmlHintRules = [
-	{ rule: "Code block - missing language", ruleLink: "https://www.ssw.com.au/rules/set-language-on-code-blocks" },
-  { rule: "Grammar mistake - common Scrum terms", ruleLink: "https://www.ssw.com.au/rules/scrum-should-be-capitalized" },
+	{ rule: "code-block-missing-language", displayName: "Code block - missing language", ruleLink: "https://www.ssw.com.au/rules/set-language-on-code-blocks" },
+  { rule: "grammar-scrum-terms", displayName: "Grammar mistake - common Scrum terms", ruleLink: "https://www.ssw.com.au/rules/scrum-should-be-capitalized" },
 	// Add new rule id below
  ];

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -345,7 +345,7 @@ export const htmlHintRules = [
 	{ rule: "spec-char-escape", displayName: "HTML - special characters must be escaped" },
 	{ rule: "id-unique", displayName: "HTML Tags - id attribute must be unique" },
 	{ rule: "src-not-empty", displayName: "Images - the src attribute must have a value" },
-	{ rule: "title-require", displayName: "HTML - missing title tag" },
+	{ rule: "title-require", displayName: "HTML Tags - missing title tag" },
 	{ rule: "alt-require", displayName: "Images - missing alt attribute" },
 	{ rule: "doctype-html5", displayName: "HTML - DOCTYPE must be HTML5" },
 	{ rule: "style-disabled", displayName: "HTML / CSS - style tags should not be used" },

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -319,33 +319,42 @@ export const getRuleLink = (errorKey) => {
   }
 };
 
+export const getDisplayText = (errorKey) => {
+  if (customHtmlHintRules.some(rule => rule.rule === errorKey)) {
+    return errorKey;
+  }
+  else {
+    var htmlHint = htmlHintRules.find(item => item.rule == errorKey);
+    return htmlHint.displayName != "" ? htmlHint.displayName : htmlHint.rule;
+  } 
+};
+
 export const htmlHintRules = [
-	{ rule: "tagname-lowercase" },
-	{ rule: "attr-lowercase" }, 
-	{ rule: "attr-value-double-quotes" },
-	{ rule: "attr-value-not-empty" },
-	{ rule: "attr-no-duplication" },
-	{ rule: "doctype-first" },
-	{ rule: "tag-pair" },
-	{ rule: "empty-tag-not-self-closed" },
-	{ rule: "spec-char-escape" },
-	{ rule: "id-unique" },
-	{ rule: "src-not-empty" },
-	{ rule: "title-require" },
-	{ rule: "alt-require" },
-	{ rule: "doctype-html5" },
-	{ rule: "style-disabled" },
-	{ rule: "inline-style-disabled" },
-	{ rule: "inline-script-disabled" },
-	{ rule: "id-class-ad-disabled" },
-	{ rule: "href-abs-or-rel" },
-	{ rule: "attr-unsafe-chars" },
-	{ rule: "head-script-disabled" },
-	{ rule: "head-script-disabled" },
+	{ rule: "tagname-lowercase", displayName: "HTML Tags - tag names must be lowercase" },
+	{ rule: "attr-lowercase", displayName: "Attributes - attribute names must be lowercase" }, 
+	{ rule: "attr-value-double-quotes", displayName: "Attributes - attribute values must be in double quotes" },
+	{ rule: "attr-value-not-empty", displayName: "Attributes - all attributes must have values" },
+	{ rule: "attr-no-duplication", displayName: "Attributes - element cannot contain duplicate attributes" },
+	{ rule: "doctype-first", displayName: "HTML - DOCTYPE must be declared first" },
+	{ rule: "tag-pair", displayName: "HTML Tags - tags must be paired" },
+	{ rule: "empty-tag-not-self-closed", displayName: "HTML Tags - an empty tag should not be closed by itself" },
+	{ rule: "spec-char-escape", displayName: "HTML - special characters must be escaped" },
+	{ rule: "id-unique", displayName: "HTML Tags - id attribute must be unique" },
+	{ rule: "src-not-empty", displayName: "Images - the src attribute must have a value" },
+	{ rule: "title-require", displayName: "HTML - missing title tag" },
+	{ rule: "alt-require", displayName: "Images - missing alt attribute" },
+	{ rule: "doctype-html5", displayName: "HTML - DOCTYPE must be HTML5" },
+	{ rule: "style-disabled", displayName: "HTML / CSS - style tags should not be used" },
+	{ rule: "inline-style-disabled", displayName: "HTML - inline styling should not be used" },
+	{ rule: "inline-script-disabled", displayName: "HTML - inline script should not be used" },
+	{ rule: "id-class-ad-disabled", displayName: "HTML Tags - id and class cannot use the ad keyword" },
+	{ rule: "href-abs-or-rel", displayName: "Links - href attribute must be either absolute or relative" },
+	{ rule: "attr-unsafe-chars", displayName: "Attributes - attributes cannot contain unsafe characters" },
+	{ rule: "head-script-disabled", displayName: "HTML - the script tag cannot be used in another tag" },
  ];
 
  export const customHtmlHintRules = [
 	{ rule: "Code block - missing language", ruleLink: "https://www.ssw.com.au/rules/set-language-on-code-blocks" },
-  { rule: "Common Agile Scrum Terms people get wrong", ruleLink: "https://www.ssw.com.au/rules/scrum-should-be-capitalized" },
+  { rule: "Grammar mistake - common Scrum terms", ruleLink: "https://www.ssw.com.au/rules/scrum-should-be-capitalized" },
 	// Add new rule id below
  ];


### PR DESCRIPTION
The label text for each CodeAuditor rule should be more human readable. 
This affects all rules on 
- Rules marketing page
- Issues found for the rules on the Report, in both "By Page" and "By Reason" tabs
- The modal when configuring which rules to run.