### PR TITLE
Summary scan card UI changes

### DIFF
--- a/ui/src/components/artillerycomponents/ArtilleryDetailsCard.svelte
+++ b/ui/src/components/artillerycomponents/ArtilleryDetailsCard.svelte
@@ -1,22 +1,16 @@
 <script>
-  import formatDistanceToNow from "date-fns/formatDistanceToNow";
-  import { printTimeDiff, CONSTS } from "../../utils/utils";
   import LighthouseSummary from "../summaryitemcomponents/LighthouseSummary.svelte";
   import { createEventDispatcher } from "svelte";
-  import { format } from "date-fns";
   import CodeSummary from "../summaryitemcomponents/CodeSummary.svelte";
   import LinkSummary from "../summaryitemcomponents/LinkSummary.svelte";
   import ArtillerySummary from "../summaryitemcomponents/ArtillerySummary.svelte";
+  import ScanSummary from "../summaryitemcomponents/ScanSummary.svelte";
 
   export let build = {};
   let val = build;
 
   const dispatch = createEventDispatcher();
   const artilleryThreshold = () => dispatch("artilleryThreshold");
-
-  function numberWithCommas(x) {
-    return x.toLocaleString()
-  }
 </script>
 
 <style>
@@ -46,27 +40,7 @@
   <div class="px-6 py-2">
     <div class="grid grid-rows-2 grid-flow-col">
       <div class="row-span-4 col-span-2">
-        <span class="font-sans text-base font-bold text-gray-800 underline">
-          {format(new Date(val.buildDate), 'dd.MM.yyyy')}
-        </span>
-        <br />
-        <span class="font-sans text-base pt-2">
-          Last scanned:
-          {formatDistanceToNow(new Date(val.buildDate), { addSuffix: true })}
-          at
-          {format(new Date(val.buildDate), 'hh:mma')}
-        </span>
-        <br />
-        <span class="font-sans text-base pt-2">
-          Duration:
-          {printTimeDiff(+val.scanDuration)}
-        </span>
-        <br />
-        <span class="font-sans text-base pt-2">
-          Scanned:
-          {numberWithCommas(val.totalScanned)}
-          items
-        </span>
+        <ScanSummary {val} />
         <br />
         <br />
         {#if val.buildDate}

--- a/ui/src/components/artillerycomponents/ArtilleryDetailsCard.svelte
+++ b/ui/src/components/artillerycomponents/ArtilleryDetailsCard.svelte
@@ -13,6 +13,10 @@
 
   const dispatch = createEventDispatcher();
   const artilleryThreshold = () => dispatch("artilleryThreshold");
+
+  function numberWithCommas(x) {
+    return x.toLocaleString()
+  }
 </script>
 
 <style>
@@ -60,7 +64,7 @@
         <br />
         <span class="font-sans text-base pt-2">
           Scanned:
-          {val.totalScanned}
+          {numberWithCommas(val.totalScanned)}
           items
         </span>
         <br />

--- a/ui/src/components/detailcardcomponents/BuildDetailsCard.svelte
+++ b/ui/src/components/detailcardcomponents/BuildDetailsCard.svelte
@@ -11,6 +11,10 @@
   export let build = {};
   let val = build;
   $: codeSummary = getCodeSummary(build);
+
+  function numberWithCommas(x) {
+    return x.toLocaleString()
+  }
 </script>
 
 <style>
@@ -55,7 +59,7 @@
         </span>
         <br />
         <span class="font-sans text-base pt-2">Scanned:
-          {val.totalScanned}
+          {numberWithCommas(val.totalScanned)}
           items</span>
       </div>
 

--- a/ui/src/components/detailcardcomponents/BuildDetailsCard.svelte
+++ b/ui/src/components/detailcardcomponents/BuildDetailsCard.svelte
@@ -1,20 +1,15 @@
 <script>
-  import formatDistanceToNow from "date-fns/formatDistanceToNow";
-  import { printTimeDiff, getCodeSummary } from "../../utils/utils";
+  import { getCodeSummary } from "../../utils/utils";
   import { navigateTo } from "svelte-router-spa";
   import LighthouseSummary from "../summaryitemcomponents/LighthouseSummary.svelte";
   import CodeSummary from "../summaryitemcomponents/CodeSummary.svelte";
   import LinkSummary from "../summaryitemcomponents/LinkSummary.svelte";
   import ArtillerySummary from "../summaryitemcomponents/ArtillerySummary.svelte";
-  import { format } from "date-fns";
+  import ScanSummary from "../summaryitemcomponents/ScanSummary.svelte";
 
   export let build = {};
   let val = build;
   $: codeSummary = getCodeSummary(build);
-
-  function numberWithCommas(x) {
-    return x.toLocaleString()
-  }
 </script>
 
 <style>
@@ -46,21 +41,7 @@
       class="grid grid-rows-2 grid-flow-col"
       on:click={() => navigateTo(`/build/${val.runId}`)}>
       <div class="row-span-4 col-span-2">
-        <span
-          class="font-sans text-base font-bold text-gray-800 underline">{format(new Date(val.buildDate), 'dd.MM.yyyy')}</span>
-        <br />
-        <span class="font-sans text-base pt-2">Last scanned:
-          {formatDistanceToNow(new Date(val.buildDate), { addSuffix: true })}
-          at
-          {format(new Date(val.buildDate), 'hh:mma')}</span>
-        <br />
-        <span class="font-sans text-base pt-2">Duration:
-          {printTimeDiff(+val.scanDuration)}
-        </span>
-        <br />
-        <span class="font-sans text-base pt-2">Scanned:
-          {numberWithCommas(val.totalScanned)}
-          items</span>
+        <ScanSummary {val} />
       </div>
 
       <div

--- a/ui/src/components/detailcardcomponents/DetailListCard.svelte
+++ b/ui/src/components/detailcardcomponents/DetailListCard.svelte
@@ -3,14 +3,10 @@
   import LinkSummary from "../summaryitemcomponents/LinkSummary.svelte";
   import LighthouseSummary from "../summaryitemcomponents/LighthouseSummary.svelte";
   import ArtillerySummary from "../summaryitemcomponents/ArtillerySummary.svelte";
-  import formatDistanceToNow from "date-fns/formatDistanceToNow";
-  import { format } from "date-fns";
-  import { printTimeDiff } from "../../utils/utils";
   import { navigateTo } from "svelte-router-spa";
+  import ScanSummary from "../summaryitemcomponents/ScanSummary.svelte";
   export let value = {};
-  function numberWithCommas(x) {
-    return x.toLocaleString()
-  }
+
 </script>
 
 <style>
@@ -52,25 +48,7 @@
         class="grid grid-rows-2 sm:gap-auto lg:grid-flow-col sm:grid-cols-3 ml-4"
         on:click={() => navigateTo(`/build/${val.runId}`)}>
         <div class="row-span-1 lg:row-span-4 col-span-4">
-          <span class="font-sans text-lg font-bold text-gray-800">
-            {format(new Date(val.buildDate), 'hh:mm a')}
-          </span>
-          <br />
-          <span class="font-sans text-lg font-bold text-gray-800">
-            {format(new Date(val.buildDate), 'dd MMMM yyyy')}
-          </span>
-          <br />
-          <span class="font-sans text-base pt-2">
-            Last scanned: {formatDistanceToNow(new Date(val.buildDate), { addSuffix: true })}
-          </span>
-          <br />
-          <span class="font-sans text-base pt-2">
-            Duration: {printTimeDiff(+val.scanDuration)}
-          </span>
-          <br />
-          <span class="font-sans text-base pt-2">
-            Scanned: {numberWithCommas(val.totalScanned)} items
-          </span>
+          <ScanSummary {val} />
         </div>
 
         <div

--- a/ui/src/components/htmlhintcomponents/HTMLHintDetailsCard.svelte
+++ b/ui/src/components/htmlhintcomponents/HTMLHintDetailsCard.svelte
@@ -1,12 +1,10 @@
 <script>
-  import formatDistanceToNow from "date-fns/formatDistanceToNow";
-  import { printTimeDiff } from "../../utils/utils";
   import { createEventDispatcher } from "svelte";
-  import { format } from "date-fns";
   import LighthouseSummary from "../summaryitemcomponents/LighthouseSummary.svelte";
   import CodeSummary from "../summaryitemcomponents/CodeSummary.svelte";
   import LinkSummary from "../summaryitemcomponents/LinkSummary.svelte";
   import ArtillerySummary from "../summaryitemcomponents/ArtillerySummary.svelte";
+  import ScanSummary from "../summaryitemcomponents/ScanSummary.svelte";
 
   export let build = {};
   export let htmlRules;
@@ -19,10 +17,6 @@
   function handleClick() {
     isCollapsedRules = !isCollapsedRules
 	}
-
-  function numberWithCommas(x) {
-    return x.toLocaleString()
-  }
 </script>
 
 <style>
@@ -52,27 +46,7 @@
   <div class="px-6 py-2">
     <div class="grid grid-rows-2 grid-flow-col">
       <div class="row-span-4 col-span-2">
-        <span class="font-sans text-base font-bold text-gray-800 underline">
-          {format(new Date(val.buildDate), 'dd.MM.yyyy')}
-        </span>
-        <br />
-        <span class="font-sans text-base pt-2">
-          Last scanned:
-          {formatDistanceToNow(new Date(val.buildDate), { addSuffix: true })}
-          at
-          {format(new Date(val.buildDate), 'hh:mma')}
-        </span>
-        <br />
-        <span class="font-sans text-base pt-2">
-          Duration:
-          {printTimeDiff(+val.scanDuration)}
-        </span>
-        <br />
-        <span class="font-sans text-base pt-2">
-          Scanned:
-          {numberWithCommas(val.totalScanned)}
-          items
-        </span>
+        <ScanSummary {val} />
         <br />
         <span class="font-sans text-base pt-2">
           {#if htmlRules}

--- a/ui/src/components/htmlhintcomponents/HTMLHintDetailsCard.svelte
+++ b/ui/src/components/htmlhintcomponents/HTMLHintDetailsCard.svelte
@@ -19,6 +19,10 @@
   function handleClick() {
     isCollapsedRules = !isCollapsedRules
 	}
+
+  function numberWithCommas(x) {
+    return x.toLocaleString()
+  }
 </script>
 
 <style>
@@ -66,7 +70,7 @@
         <br />
         <span class="font-sans text-base pt-2">
           Scanned:
-          {val.totalScanned}
+          {numberWithCommas(val.totalScanned)}
           items
         </span>
         <br />

--- a/ui/src/components/lighthousecomponents/LighthouseDetailsCard.svelte
+++ b/ui/src/components/lighthousecomponents/LighthouseDetailsCard.svelte
@@ -1,12 +1,10 @@
 <script>
-  import formatDistanceToNow from "date-fns/formatDistanceToNow";
-  import { printTimeDiff } from "../../utils/utils";
   import LighthouseSummary from "../summaryitemcomponents/LighthouseSummary.svelte";
   import { createEventDispatcher } from "svelte";
-  import { format } from "date-fns";
   import CodeSummary from "../summaryitemcomponents/CodeSummary.svelte";
   import LinkSummary from "../summaryitemcomponents/LinkSummary.svelte";
   import ArtillerySummary from "../summaryitemcomponents/ArtillerySummary.svelte";
+  import ScanSummary from "../summaryitemcomponents/ScanSummary.svelte";
 
   export let build = {};
   let val = build;
@@ -42,21 +40,7 @@
   <div class="px-6 py-2">
     <div class="grid grid-rows-2 grid-flow-col">
       <div class="row-span-4 col-span-2">
-        <span
-          class="font-sans text-base font-bold text-gray-800 underline">{format(new Date(val.buildDate), 'dd.MM.yyyy')}</span>
-        <br />
-        <span class="font-sans text-base pt-2">Last scanned:
-          {formatDistanceToNow(new Date(val.buildDate), { addSuffix: true })}
-          at
-          {format(new Date(val.buildDate), 'hh:mma')}</span>
-        <br />
-        <span class="font-sans text-base pt-2">Duration:
-          {printTimeDiff(+val.scanDuration)}
-        </span>
-        <br />
-        <span class="font-sans text-base pt-2">Scanned:
-          {val.totalScanned}
-          items</span>
+        <ScanSummary {val} />
         <br />
         <br />
         {#if val.buildDate}

--- a/ui/src/components/summaryitemcomponents/ArtillerySummary.svelte
+++ b/ui/src/components/summaryitemcomponents/ArtillerySummary.svelte
@@ -10,19 +10,19 @@
   <div class="col-span-1 text-start">
     <span class="block font-sans">Latency P95</span>
     <span
-      class="font-sans font-bold block lg:inline-block">{numberWithCommas(value.latencyP95 === undefined ? '0' : value.latencyP95)}
+      class="font-sans font-bold block lg:inline-block">{numberWithCommas(value.latencyP95 === undefined ? '0' : value.latencyP95)}ms
     </span>
   </div>
   <div class="col-span-1 text-start">
     <span class="block whitespace-no-wrap font-sans">Requests</span>
     <span class="font-sans font-bold block lg:inline-block">
-      {numberWithCommas(value.requestsCompleted)}
+      {numberWithCommas(value.requestsCompleted)}ms
     </span>
   </div>
   <div class="col-span-1 text-start">
     <span class="block whitespace-no-wrap font-sans">Errors</span>
     <span class="font-sans font-bold block lg:inline-block">
-      {numberWithCommas(value.errors)}
+      {numberWithCommas(value.errors)} 
     </span>
   </div>
 </div>

--- a/ui/src/components/summaryitemcomponents/ArtillerySummary.svelte
+++ b/ui/src/components/summaryitemcomponents/ArtillerySummary.svelte
@@ -16,7 +16,7 @@
   <div class="col-span-1 text-start">
     <span class="block whitespace-no-wrap font-sans">Requests</span>
     <span class="font-sans font-bold block lg:inline-block">
-      {numberWithCommas(value.requestsCompleted)}ms
+      {numberWithCommas(value.requestsCompleted)}
     </span>
   </div>
   <div class="col-span-1 text-start">

--- a/ui/src/components/summaryitemcomponents/ArtillerySummary.svelte
+++ b/ui/src/components/summaryitemcomponents/ArtillerySummary.svelte
@@ -1,24 +1,28 @@
 <script>
   export let value = {};
+
+  function numberWithCommas(x) {
+    return Math.round(x).toLocaleString()
+  }
 </script>
 
 <div class="grid grid-cols-2 lg:grid-cols-4 gap-x-5">
   <div class="col-span-1 text-start">
     <span class="block font-sans">Latency P95</span>
     <span
-      class="font-sans font-bold block lg:inline-block">{value.latencyP95 === undefined ? '0' : value.latencyP95}
+      class="font-sans font-bold block lg:inline-block">{numberWithCommas(value.latencyP95 === undefined ? '0' : value.latencyP95)}
     </span>
   </div>
   <div class="col-span-1 text-start">
     <span class="block whitespace-no-wrap font-sans">Requests</span>
     <span class="font-sans font-bold block lg:inline-block">
-      {value.requestsCompleted}
+      {numberWithCommas(value.requestsCompleted)}
     </span>
   </div>
   <div class="col-span-1 text-start">
     <span class="block whitespace-no-wrap font-sans">Errors</span>
     <span class="font-sans font-bold block lg:inline-block">
-      {value.errors}
+      {numberWithCommas(value.errors)}
     </span>
   </div>
 </div>

--- a/ui/src/components/summaryitemcomponents/ArtillerySummary.svelte
+++ b/ui/src/components/summaryitemcomponents/ArtillerySummary.svelte
@@ -2,7 +2,7 @@
   export let value = {};
 </script>
 
-<div class="grid grid-cols-2 lg:grid-cols-4">
+<div class="grid grid-cols-2 lg:grid-cols-4 gap-x-5">
   <div class="col-span-1 text-start">
     <span class="block font-sans">Latency P95</span>
     <span
@@ -10,13 +10,13 @@
     </span>
   </div>
   <div class="col-span-1 text-start">
-    <span class="block whitespace-no-wrap font-sans">REQUESTS</span>
+    <span class="block whitespace-no-wrap font-sans">Requests</span>
     <span class="font-sans font-bold block lg:inline-block">
       {value.requestsCompleted}
     </span>
   </div>
   <div class="col-span-1 text-start">
-    <span class="block whitespace-no-wrap font-sans">ERRORS</span>
+    <span class="block whitespace-no-wrap font-sans">Errors</span>
     <span class="font-sans font-bold block lg:inline-block">
       {value.errors}
     </span>

--- a/ui/src/components/summaryitemcomponents/CodeSummary.svelte
+++ b/ui/src/components/summaryitemcomponents/CodeSummary.svelte
@@ -11,10 +11,10 @@
   $: codeSummary = getCodeSummary(value);
 </script>
 
-<div class="grid grid-cols-2 lg:grid-cols-4">
+<div class="grid grid-cols-2 lg:grid-cols-4 gap-x-5">
   {#if codeSummary.cloc}
     <div class="col-span-1 text-start">
-      <span class="block whitespace-no-wrap font-sans">TOTAL FILES</span>
+      <span class="block whitespace-no-wrap font-sans">Total Files</span>
       <span
         class="font-sans font-bold block lg:inline-block"
         title="Number of files">
@@ -22,7 +22,7 @@
       </span>
     </div>
     <div class="col-span-1 text-start">
-      <span class="block whitespace-no-wrap font-sans">TOTAL LINES</span>
+      <span class="block whitespace-no-wrap font-sans">Total Lines</span>
       <span
         class="font-sans font-bold block lg:inline-block"
         title="Number of lines of codes">
@@ -33,7 +33,7 @@
 
   {#if codeSummary.html || codeSummary.code}
   <div class="col-span-1 text-start">
-    <span class="block whitespace-no-wrap font-sans">BAD CODE</span>
+    <span class="block whitespace-no-wrap font-sans">Errors</span>
     <span
       class="font-sans font-bold block lg:inline-block"
       title={(codeSummary.codeIssueList || '') + '\n\n\n' + (codeSummary.htmlIssueList || '')}>
@@ -41,7 +41,7 @@
     </span>
   </div>
     <div class="col-span-1 text-start">
-      <span class="block whitespace-no-wrap font-sans">CODE WARNINGS</span>
+      <span class="block whitespace-no-wrap font-sans">Warnings</span>
       <span
         class="font-sans font-bold block lg:inline-block"
         title={(codeSummary.codeIssueList || '') + '\n\n\n' + (codeSummary.htmlIssueList || '')}>

--- a/ui/src/components/summaryitemcomponents/LighthouseSummary.svelte
+++ b/ui/src/components/summaryitemcomponents/LighthouseSummary.svelte
@@ -7,9 +7,9 @@
 {#if perf.performanceScore}
   <!-- content here -->
   <div>
-    <div class="grid grid-cols-2 lg:grid-cols-4">
+    <div class="grid grid-cols-2 lg:grid-cols-4 gap-x-5">
       <div class="col-span-1 text-start whitespace-no-wrap">
-        <span class="block font-sans">AVERAGE</span>
+        <span class="block font-sans">Average</span>
         <span
           class="font-bold block lg:inline-block textgrey"
           title="Average"
@@ -18,7 +18,7 @@
         </span>
       </div>
       <div class="col-span-1 text-start">
-        <span class="block font-sans">PERFORMANCE</span>
+        <span class="block font-sans">Performance</span>
         <span
           title="Performance"
           class="font-bold block lg:inline-block textgrey"
@@ -27,7 +27,7 @@
         </span>
       </div>
       <div class="col-span-1 text-start">
-        <span class="block font-sans">ACCESSIBILITY</span>
+        <span class="block font-sans">Accessibility</span>
         <span
           class="font-bold block lg:inline-block textgrey"
           title="Accessibility"
@@ -55,7 +55,7 @@
         </span>
       </div>
       <div class="text-start">
-        <span class="block font-sans">BEST PRACTICE</span>
+        <span class="block font-sans">Best Practice</span>
         <span
           class="font-bold block lg:inline-block textgrey"
           title="Best Practice"

--- a/ui/src/components/summaryitemcomponents/LinkSummary.svelte
+++ b/ui/src/components/summaryitemcomponents/LinkSummary.svelte
@@ -6,14 +6,14 @@
   }
 </script>
 
-<div class="grid grid-cols-2 lg:grid-cols-4">
+<div class="grid grid-cols-2 lg:grid-cols-4 gap-x-5">
   <div class="col-span-1 text-start">
-    <span class="block font-sans">SCANNED</span>
+    <span class="block font-sans">Scanned</span>
     <span
       class="font-sans font-bold block lg:inline-block">{numberWithCommas(value.totalScanned)}</span>
   </div>
   <div class="col-span-1 text-start">
-    <span class="block whitespace-no-wrap font-sans">BAD LINKS</span>
+    <span class="block whitespace-no-wrap font-sans">Bad Links</span>
     <span
       class="font-sans font-bold block lg:inline-block"
       class:text-red-600={value.totalBrokenLinks > 0}
@@ -22,7 +22,7 @@
     </span>
   </div>
   <div class="col-span-1 text-start">
-    <span class="block whitespace-no-wrap font-sans">404 ERRORS</span>
+    <span class="block whitespace-no-wrap font-sans">404 Errors</span>
     <span
       class="font-sans font-bold block lg:inline-block"
       class:text-red-600={value.totalUnique404 > 0}

--- a/ui/src/components/summaryitemcomponents/ScanSummary.svelte
+++ b/ui/src/components/summaryitemcomponents/ScanSummary.svelte
@@ -1,7 +1,7 @@
 <script>
     import { format } from "date-fns";
     import formatDistanceToNow from "date-fns/formatDistanceToNow";
-    import { printTimeDiff, CONSTS } from "../../utils/utils";
+    import { printTimeDiff } from "../../utils/utils";
 
     export let val
 

--- a/ui/src/components/summaryitemcomponents/ScanSummary.svelte
+++ b/ui/src/components/summaryitemcomponents/ScanSummary.svelte
@@ -1,0 +1,33 @@
+<script>
+    import { format } from "date-fns";
+    import formatDistanceToNow from "date-fns/formatDistanceToNow";
+    import { printTimeDiff, CONSTS } from "../../utils/utils";
+
+    export let val
+
+    function numberWithCommas(x) {
+    return x.toLocaleString()
+  }
+</script>
+
+<span class="font-sans text-base font-bold text-gray-800 underline">
+    {format(new Date(val.buildDate), 'dd.MM.yyyy')}
+  </span>
+  <br />
+  <span class="font-sans text-base pt-2">
+    Last scanned:
+    {formatDistanceToNow(new Date(val.buildDate), { addSuffix: true })}
+    at
+    {format(new Date(val.buildDate), 'hh:mma')}
+  </span>
+  <br />
+  <span class="font-sans text-base pt-2">
+    Duration:
+    {printTimeDiff(+val.scanDuration)}
+  </span>
+  <br />
+  <span class="font-sans text-base pt-2">
+    Scanned:
+    {numberWithCommas(val.totalScanned)}
+    items
+  </span>

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -63,7 +63,7 @@ export const CONSTS = {
 export const printTimeDiff = (took) =>
 	Math.floor((took || 0) / 60)
 	.toString()
-	.padStart(2, '0') +
+	.padStart(0, '0') +
 	'm ' +
 	Math.floor((took || 0) % 60)
 	.toString()

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -64,10 +64,10 @@ export const printTimeDiff = (took) =>
 	Math.floor((took || 0) / 60)
 	.toString()
 	.padStart(2, '0') +
-	':' +
+	'm ' +
 	Math.floor((took || 0) % 60)
 	.toString()
-	.padStart(2, '0');
+	.padStart(2, '0') + 's';
 
 export const updateQuery = (q) => {
 	if (history.pushState) {


### PR DESCRIPTION
- Adjusted Titles to undercase and renamed bad code titles
- Added thousand separator and removed decimal places
- Created reusable ScanSummary component
- Reformatted duration number to '17m 23s'

![image](https://user-images.githubusercontent.com/67776356/120965482-4cb07d00-c7a8-11eb-8cd4-3263562c1bc9.png)

**Figure: New summary card UI**