### PR TITLE
Fixed data language custom rule

### DIFF
--- a/docker/customHtmlRules.js
+++ b/docker/customHtmlRules.js
@@ -12,10 +12,12 @@ exports.addCustomHtmlRule = () => {
             var tagName = event.tagName.toLowerCase(),
               mapAttrs = parser.getMapAttrs(event.attrs),
               col = event.col + tagName.length + 1;
-            if (tagName === "pre" || tagName === "code") {
+            if (tagName === "pre") {
               if (
-                !("class" in mapAttrs) ||
-                !mapAttrs["class"].includes("language")
+                (!("class" in mapAttrs) ||
+                !mapAttrs["class"].includes("language"))  &&
+                (!("data-language" in mapAttrs) ||
+                (mapAttrs["data-language"] === ""))
               ) {
                 reporter.warn(
                   "Code blocks must contain a language specifier.",


### PR DESCRIPTION
Custom rule to check for "data-language" attribute

```html 
<pre class="grvsc-container default-dark" data-language="cs" data-index="0">
```

**Figure: check if data-language attribute is present**