### PR TITLE
Summary card UI changes

### DIFF
--- a/ui/src/components/misccomponents/TooltipFromAction.svelte
+++ b/ui/src/components/misccomponents/TooltipFromAction.svelte
@@ -1,0 +1,19 @@
+<script>
+	export let title;
+	export let x;
+	export let y;
+</script>
+<div style="
+		top: {y + 5}px;
+		left: {x + 5}px;">{title}</div>
+
+<style>
+	div {
+		border: 1px solid #ddd;
+		box-shadow: 1px 1px 1px #ddd;
+		background: white;
+		border-radius: 4px;
+		padding: 4px;
+		position: absolute;
+	}
+</style>

--- a/ui/src/components/misccomponents/tooltip.js
+++ b/ui/src/components/misccomponents/tooltip.js
@@ -1,0 +1,45 @@
+import Tooltip from './TooltipFromAction.svelte';
+
+export function tooltip(element) {
+	let div;
+	let title;
+	let tooltipComponent;
+	function mouseOver(event) {
+		// NOTE: remove the `title` attribute, to prevent showing the default browser tooltip
+		// remember to set it back on `mouseleave`
+		title = element.getAttribute('title');
+		element.removeAttribute('title');
+
+		tooltipComponent = new Tooltip({
+			props: {
+				title: title,
+				x: event.pageX,
+				y: event.pageY,
+			},
+			target: document.body,
+		});
+	}
+	function mouseMove(event) {
+		tooltipComponent.$set({
+			x: event.pageX,
+			y: event.pageY,
+		})
+	}
+	function mouseLeave() {
+		tooltipComponent.$destroy();
+		// NOTE: restore the `title` attribute
+		element.setAttribute('title', title);
+	}
+	
+	element.addEventListener('mouseover', mouseOver);
+  element.addEventListener('mouseleave', mouseLeave);
+	element.addEventListener('mousemove', mouseMove);
+	
+	return {
+		destroy() {
+			element.removeEventListener('mouseover', mouseOver);
+			element.removeEventListener('mouseleave', mouseLeave);
+			element.removeEventListener('mousemove', mouseMove);
+		}
+	}
+}

--- a/ui/src/components/summaryitemcomponents/ArtillerySummary.svelte
+++ b/ui/src/components/summaryitemcomponents/ArtillerySummary.svelte
@@ -27,6 +27,9 @@
       class:text-gray-600={value.errors == 0}
     >
       {numberWithCommas(value.errors)} 
+      {#if value.errors === 0}
+        <i class="fas fa-check"></i>
+      {/if}
     </span>
   </div>
 </div>

--- a/ui/src/components/summaryitemcomponents/CodeSummary.svelte
+++ b/ui/src/components/summaryitemcomponents/CodeSummary.svelte
@@ -43,6 +43,9 @@
       class:text-gray-600={codeSummary.htmlWarnings == 0}
       title={(codeSummary.codeIssueList || '') + '\n\n\n' + (codeSummary.htmlIssueList || '')}>
       {numberWithCommas((codeSummary.htmlWarnings || 0) + (codeSummary.codeWarnings || 0))}
+      {#if codeSummary.htmlWarnings == 0}
+        <i class="fas fa-check"></i>
+      {/if}
     </span>
   </div>
     <div class="col-span-1 text-start">
@@ -55,6 +58,9 @@
         class:text-gray-600={codeSummary.htmlErrors === 0}
         title={(codeSummary.codeIssueList || '') + '\n\n\n' + (codeSummary.htmlIssueList || '')}>
         {numberWithCommas((codeSummary.htmlErrors || 0) + (codeSummary.codeErrors || 0))}
+        {#if codeSummary.htmlErrors == 0}
+          <i class="fas fa-check"></i>
+        {/if}
       </span>
     </div>
     {:else}

--- a/ui/src/components/summaryitemcomponents/CodeSummary.svelte
+++ b/ui/src/components/summaryitemcomponents/CodeSummary.svelte
@@ -2,6 +2,7 @@
   import {
    getCodeSummary,
   } from "../../utils/utils";
+  import { tooltip } from '../misccomponents/tooltip';
   export let value = {};
 
   function numberWithCommas(x) {
@@ -33,7 +34,9 @@
 
   {#if codeSummary.htmlWarnings || codeSummary.htmlErrors}
   <div class="col-span-1 text-start">
-    <span class="block whitespace-no-wrap font-sans">Warnings</span>
+    <span class="block whitespace-no-wrap font-sans">Warnings
+      <i class="fas fa-info-circle" title="HTML issues against the standard but that are less likely to be problematic" use:tooltip></i>
+    </span>
     <span
       class="font-sans font-bold block lg:inline-block"
       class:text-red-600={codeSummary.htmlWarnings > 0}
@@ -43,7 +46,9 @@
     </span>
   </div>
     <div class="col-span-1 text-start">
-      <span class="block whitespace-no-wrap font-sans">Errors</span>
+      <span class="block whitespace-no-wrap font-sans">Errors
+        <i class="fas fa-info-circle" title="HTML issues that are flagrantly against the standards" use:tooltip></i>
+      </span>
       <span
         class="font-sans font-bold block lg:inline-block"
         class:text-red-600={codeSummary.htmlErrors > 0}
@@ -54,18 +59,22 @@
     </div>
     {:else}
     <div class="col-span-1 text-start">
-      <span class="block whitespace-no-wrap font-sans">Errors</span>
+      <span class="block whitespace-no-wrap font-sans">Warnings
+        <i class="fas fa-info-circle" title="HTML issues against the standard but that are less likely to be problematic" use:tooltip></i>
+      </span>
       <span
         class="font-sans font-bold block lg:inline-block">
         N/A
       </span>
     </div>
-      <div class="col-span-1 text-start">
-        <span class="block whitespace-no-wrap font-sans">Warnings</span>
-        <span
-          class="font-sans font-bold block lg:inline-block">
-          N/A
-        </span>
-      </div>
+    <div class="col-span-1 text-start">
+      <span class="block whitespace-no-wrap font-sans">Errors
+        <i class="fas fa-info-circle" title="HTML issues that are flagrantly against the standards" use:tooltip></i>
+      </span>
+      <span
+        class="font-sans font-bold block lg:inline-block">
+        N/A
+      </span>
+    </div>
   {/if}
 </div>

--- a/ui/src/components/summaryitemcomponents/LinkSummary.svelte
+++ b/ui/src/components/summaryitemcomponents/LinkSummary.svelte
@@ -1,6 +1,8 @@
 <script>
   export let value = {};
 
+  import { tooltip } from '../misccomponents/tooltip';
+
   function numberWithCommas(x) {
     return x.toLocaleString()
   }
@@ -13,7 +15,9 @@
       class="font-sans font-bold block lg:inline-block">{numberWithCommas(value.totalScanned)}</span>
   </div>
   <div class="col-span-1 text-start">
-    <span class="block whitespace-no-wrap font-sans">Bad Links</span>
+    <span class="block whitespace-no-wrap font-sans">Bad Links
+      <i class="fas fa-info-circle" title="Unique Links / Total Links" use:tooltip></i>
+    </span>
     <span
       class="font-sans font-bold block lg:inline-block"
       class:text-red-600={value.totalBrokenLinks > 0}

--- a/ui/src/components/summaryitemcomponents/LinkSummary.svelte
+++ b/ui/src/components/summaryitemcomponents/LinkSummary.svelte
@@ -22,7 +22,11 @@
       class="font-sans font-bold block lg:inline-block"
       class:text-red-600={value.totalBrokenLinks > 0}
       class:text-gray-600={value.totalBrokenLinks === 0}>
-      {value.uniqueBrokenLinks} / {value.totalBrokenLinks}
+      {#if value.uniqueBrokenLinks === value.totalBrokenLinks}
+        {value.uniqueBrokenLinks}
+      {:else}
+        {value.uniqueBrokenLinks} / {value.totalBrokenLinks}
+      {/if}
       {#if value.totalBrokenLinks === 0}
         <i class="fas fa-check"></i>
       {/if}

--- a/ui/src/components/summaryitemcomponents/LinkSummary.svelte
+++ b/ui/src/components/summaryitemcomponents/LinkSummary.svelte
@@ -23,6 +23,9 @@
       class:text-red-600={value.totalBrokenLinks > 0}
       class:text-gray-600={value.totalBrokenLinks === 0}>
       {value.uniqueBrokenLinks} / {value.totalBrokenLinks}
+      {#if value.totalBrokenLinks === 0}
+        <i class="fas fa-check"></i>
+      {/if}
     </span>
   </div>
   <div class="col-span-1 text-start">
@@ -32,6 +35,9 @@
       class:text-red-600={value.totalUnique404 > 0}
       class:text-gray-600={value.totalUnique404 === 0}>
       {value.totalUnique404}
+      {#if value.totalUnique404 === 0}
+        <i class="fas fa-check"></i>
+      {/if}
     </span>
   </div>
 </div>


### PR DESCRIPTION
- Add a grey tooltip indicating what a "Code Error" is and what a "Code Warning" is
- Add a grey tick next to the Bad Links when it is 0.
- If the "Bad Links" numbers are the same, hide one of them.

<img width="1283" alt="image" src="https://user-images.githubusercontent.com/67776356/122169316-9e4fba80-cec0-11eb-94f7-b7e33830e183.png">

**Figure: New UI Changes**

<img width="413" alt="image" src="https://user-images.githubusercontent.com/67776356/122169371-ab6ca980-cec0-11eb-9835-e17895b79b70.png">
<img width="640" alt="image" src="https://user-images.githubusercontent.com/67776356/122169400-b1fb2100-cec0-11eb-860a-da63fdf4c4ad.png">
<img width="578" alt="image" src="https://user-images.githubusercontent.com/67776356/122169427-b7586b80-cec0-11eb-9d58-7ccd11189de8.png">

**Figure: New Tooltip messages**