### PR TITLE
Homepage UI improvement

### DIFF
--- a/ui/src/components/buildlistcardcomponents/BuildList.svelte
+++ b/ui/src/components/buildlistcardcomponents/BuildList.svelte
@@ -116,14 +116,11 @@
                 type="button"
                 class="hover:bg-gray-300 border-0 rounded-md px-3 py-1"
                 on:click={() => toggle(i)}>
-                <svg
-                  class="w-6 h-6"
-                  fill="currentColor"
-                  viewBox="0 0 20 20"
-                  xmlns="http://www.w3.org/2000/svg"><path
-                    fill-rule="evenodd"
-                    d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-                    clip-rule="evenodd" /></svg>
+                {#if showTotalBuild}
+                  <i class="fas fa-angle-up"></i>
+                {:else}
+                  <i class="fas fa-angle-down"></i>
+                {/if}
               </span>
               <p class="truncate font-sans font-bold text-xs">
                 Total build:

--- a/ui/src/components/summaryitemcomponents/CodeSummary.svelte
+++ b/ui/src/components/summaryitemcomponents/CodeSummary.svelte
@@ -35,7 +35,7 @@
   {#if codeSummary.htmlWarnings || codeSummary.htmlErrors}
   <div class="col-span-1 text-start">
     <span class="block whitespace-no-wrap font-sans">Warnings
-      <i class="fas fa-info-circle" title="HTML issues against the standard but that are less likely to be problematic" use:tooltip></i>
+      <i class="fas fa-info-circle" title="😵" use:tooltip></i>
     </span>
     <span
       class="font-sans font-bold block lg:inline-block"
@@ -50,7 +50,7 @@
   </div>
     <div class="col-span-1 text-start">
       <span class="block whitespace-no-wrap font-sans">Errors
-        <i class="fas fa-info-circle" title="HTML issues that are flagrantly against the standards" use:tooltip></i>
+        <i class="fas fa-info-circle" title="😡" use:tooltip></i>
       </span>
       <span
         class="font-sans font-bold block lg:inline-block"
@@ -66,7 +66,7 @@
     {:else}
     <div class="col-span-1 text-start">
       <span class="block whitespace-no-wrap font-sans">Warnings
-        <i class="fas fa-info-circle" title="HTML issues against the standard but that are less likely to be problematic" use:tooltip></i>
+        <i class="fas fa-info-circle" title="😵" use:tooltip></i>
       </span>
       <span
         class="font-sans font-bold block lg:inline-block">
@@ -75,7 +75,7 @@
     </div>
     <div class="col-span-1 text-start">
       <span class="block whitespace-no-wrap font-sans">Errors
-        <i class="fas fa-info-circle" title="HTML issues that are flagrantly against the standards" use:tooltip></i>
+        <i class="fas fa-info-circle" title="😡" use:tooltip></i>
       </span>
       <span
         class="font-sans font-bold block lg:inline-block">

--- a/ui/src/containers/Dashboard.svelte
+++ b/ui/src/containers/Dashboard.svelte
@@ -69,7 +69,7 @@
 
   const summarizedInstructions = `
   ## About SSW CodeAuditor
-  SSW CodeAuditor was launched in 2008. It was built and is lovingly maintained by SSW.
+  SSW CodeAuditor was launched in 2008. It was built and is lovingly maintained by [SSW](https://www.ssw.com.au/ssw/).
   ## Get Started
   Scan any website for broken links and [HTML Issues](https://htmlhint.com) by running the following command:
   \`\`\` bash
@@ -170,7 +170,7 @@
         </article>
         <div class="mt-2 flex-none">
           <button
-            class="bg-red-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+            class="bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded"
             on:click={showFullInstruction}>
             Less Options
             <i class="fas fa-angle-up"></i>
@@ -182,7 +182,7 @@
         </article>
         <div class="mt-2 flex-none">
           <button
-            class="flex-none bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+            class="flex-none bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded"
             on:click={showFullInstruction}>
             More Options
             <i class="fas fa-angle-down"></i>

--- a/ui/src/containers/Dashboard.svelte
+++ b/ui/src/containers/Dashboard.svelte
@@ -173,7 +173,7 @@
             class="bg-red-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
             on:click={showFullInstruction}>
             Less Options
-            <i class="fas fa-minus-square"></i>
+            <i class="fas fa-angle-up"></i>
           </button>
         </div>
       {:else}
@@ -185,7 +185,7 @@
             class="flex-none bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
             on:click={showFullInstruction}>
             More Options
-            <i class="fas fa-plus-square"></i>
+            <i class="fas fa-angle-down"></i>
           </button>
         </div>
       {/if}

--- a/ui/src/containers/Public.svelte
+++ b/ui/src/containers/Public.svelte
@@ -80,7 +80,7 @@
             class="bg-red-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
             on:click={showFullInstruction}>
             Less Options
-            <i class="fas fa-minus-square"></i>
+            <i class="fas fa-angle-up"></i>
           </button>
         </div>
       {:else}
@@ -92,7 +92,7 @@
             class="flex-none bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
             on:click={showFullInstruction}>
             More Options
-            <i class="fas fa-plus-square"></i>
+            <i class="fas fa-angle-down"></i>
           </button>
         </div>
       {/if}

--- a/ui/src/containers/Public.svelte
+++ b/ui/src/containers/Public.svelte
@@ -30,7 +30,7 @@
 
   const instruction = `
   ## About SSW CodeAuditor
-  SSW CodeAuditor was launched in 2008. It was built and is lovingly maintained by SSW.
+  SSW CodeAuditor was launched in 2008. It was built and is lovingly maintained by [SSW](https://www.ssw.com.au/ssw/).
   ## Get Started
   Scan any website for broken links, [HTML Issues](https://htmlhint.com), [Google Lighthouse Audit](https://developers.google.com/web/tools/lighthouse) and [Artillery Load Test](https://artillery.io/) by running the following command:
   \`\`\` bash
@@ -77,7 +77,7 @@
         </article>
         <div class="mt-2 flex-none">
           <button
-            class="bg-red-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+            class="bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded"
             on:click={showFullInstruction}>
             Less Options
             <i class="fas fa-angle-up"></i>
@@ -89,7 +89,7 @@
         </article>
         <div class="mt-2 flex-none">
           <button
-            class="flex-none bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+            class="flex-none bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded"
             on:click={showFullInstruction}>
             More Options
             <i class="fas fa-angle-down"></i>

--- a/ui/src/containers/PublicBuilds.svelte
+++ b/ui/src/containers/PublicBuilds.svelte
@@ -64,7 +64,7 @@
           <p
             class="cursor-pointer underline text-gray-700 font-sans font-bold hover:text-red-600"
             on:click={showAllScan}>
-            Showing all
+            Showing top
             {data.length}
             Public Scans
           </p>


### PR DESCRIPTION
- On Explore page, change from "Showing all 1000 scans" To "Showing top 1000 scans"
- Change button icon To "More ^" and "Less (down symbol)"
- Change scan card list icon to "Up" and "Down" symbol similar to Figure above
- Review the buttons colors with Tiago, changed to dark grey color
- Change the tooltip messages on tooltip
Code Errors To "😡"
Code Warnings To "😵"