### PR TITLE
Migrated back instead of previous link rule

### DIFF
--- a/docker/api.js
+++ b/docker/api.js
@@ -95,4 +95,5 @@ exports.htmlHintConfig = {
   "href-abs-or-rel": true,
   "attr-unsafe-chars": true,
   "head-script-disabled": true,
+  "back-link-instead-of-previous": true
 };

--- a/docker/customHtmlRules.js
+++ b/docker/customHtmlRules.js
@@ -32,7 +32,7 @@ exports.addCustomHtmlRule = () => {
         },
       });
 
-      HTMLHint.addRule({
+    HTMLHint.addRule({
         id: "grammar-scrum-terms",
         description: "Checks case of common Agile Scrum terms that people get wrong.",
         init: function (parser, reporter) {
@@ -59,6 +59,34 @@ exports.addCustomHtmlRule = () => {
                   );
                 }
               });
+            }
+          });
+        },
+      });
+
+    HTMLHint.addRule({
+        id: "back-link-instead-of-previous",
+        description: "Checks using 'Back' instead of 'Previous' for backward iteration. ",
+        init: function (parser, reporter) {
+          var self = this;
+  
+          parser.addListener('all', function (event) {
+            if (event.tagName === 'a') {
+              if (event.lastEvent.raw === " &lt;Back " ||
+                  event.lastEvent.raw === " &lt;&lt;Back" ||
+                  event.lastEvent.raw === " &lt;&lt; Back" ||
+                  event.lastEvent.raw === " &lt;Previous " ||
+                  event.lastEvent.raw === " &lt;&lt;Previous " ||
+                  event.lastEvent.raw === " &lt; Previous " 
+              ) {
+                reporter.warn(
+                  "Use Previous instead of Back",
+                  event.line,
+                  event.col,
+                  self,
+                  event.raw
+                );
+              }
             }
           });
         },

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -357,10 +357,12 @@ export const htmlHintRules = [
 	{ rule: "head-script-disabled", displayName: "HTML - the script tag cannot be used in another tag", ruleLink: "https://htmlhint.com/docs/user-guide/rules/head-script-disabled" },
 	{ rule: "code-block-missing-language", displayName: "Code block - missing language", ruleLink: "https://www.ssw.com.au/rules/set-language-on-code-blocks" },
 	{ rule: "grammar-scrum-terms", displayName: "Grammar mistake - common Scrum terms", ruleLink: "https://www.ssw.com.au/rules/scrum-should-be-capitalized" },
+	{ rule: "back-link-instead-of-previous", displayName: "Do you use 'Back' instead of 'Previous' (or other variations)?", ruleLink: "https://www.ssw.com.au/rules/do-you-use-back-instead-of-previous-or-other-variations" },
  ];
 
  export const customHtmlHintRules = [
 	{ rule: "code-block-missing-language", displayName: "Code block - missing language", ruleLink: "https://www.ssw.com.au/rules/set-language-on-code-blocks" },
 	{ rule: "grammar-scrum-terms", displayName: "Grammar mistake - common Scrum terms", ruleLink: "https://www.ssw.com.au/rules/scrum-should-be-capitalized" },
+	{ rule: "back-link-instead-of-previous", displayName: "Do you use 'Back' instead of 'Previous' (or other variations)?", ruleLink: "https://www.ssw.com.au/rules/do-you-use-back-instead-of-previous-or-other-variations" },
 	// Add new rule id below
  ];


### PR DESCRIPTION
Migrate the rule 'Do you use "Back" instead of "Previous" (or other variations)?'

SSW Rules: https://www.ssw.com.au/rules/do-you-use-back-instead-of-previous-or-other-variations

Bad Example HTML: https://60d934185efa7.htmlsave.net

