### PR TITLE
Improve Unscannable Links UI

### DIFF
--- a/ui/public/global.css
+++ b/ui/public/global.css
@@ -86,12 +86,17 @@ button:focus {
 }
 
 .link {
-	border-bottom: 1px dotted #9e9e9e;
-	background-color: transparent;
+    text-decoration: underline;
+    text-decoration-color: #aaa;
+    text-decoration-style: solid;
+    text-decoration-thickness: 1px;
+    transition: color .25s ease;
+    word-break: break-word;
 }
+
 .link:hover {
-	color: #cc4141;
-	text-decoration: none !important;
+    color: #cc4141;
+    text-decoration-color: #cc4141;
 }
 
 .bordered {

--- a/ui/src/components/linkauditorcomponents/DetailsTable.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsTable.svelte
@@ -126,7 +126,7 @@
             <path d="M9 5l7 7-7 7" />
           {/if}
         </Icon>
-      Unscannable Links:
+      Unscannable Links ({foundUnscannableLinks.length}):
     </span>
     {#if !hiddenRows}
       <span class="mb-3">
@@ -139,18 +139,18 @@
           out:fade={{ y: -100, duration: 200 }}>
           <tbody>
             <tr>
-              <th class="table-header md:table-cell w-4/12 md:w-2/12 px-4 py-2">Source</th>
+              <th class="table-header md:table-cell w-2/12 px-4 py-2">Source</th>
               <td class="w-10/12 border px-4 py-2 break-all">
                 <a class="inline-block align-baseline link" target="_blank" href={url.src}>{url.src + 'sdfwdfdsfdsdfdsdfddsdfsdfsffsdfd'}</a>
               </td> 
             </tr>
           
             <tr>
-              <th class="table-header md:table-cell w-4/12 md:w-2/12 px-4 py-2">Anchor Text</th>
+              <th class="table-header md:table-cell w-2/12 px-4 py-2">Anchor Text</th>
               <td class="md:table-cell w-10/12 border px-4 py-2 break-all">{url.link || ''}</td>
             </tr>
             <tr>
-              <th class="table-header w-4/12 md:w-2/12 px-4 py-2">Unscannable Link</th> 
+              <th class="table-header w-2/12 px-4 py-2">Link</th> 
               <td class="w-10/12 border px-4 py-2 break-all">
                 <a class="inline-block align-baseline link" target="_blank" href={url.dst}>{url.dst}</a>
               </td>    

--- a/ui/src/components/linkauditorcomponents/DetailsTable.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsTable.svelte
@@ -52,6 +52,13 @@
   .active:visited {
     color: #cc4141;
   }
+  .table-header {
+    text-align: right;
+    background: #eee;
+    border-style: solid;
+    border-color: #ccc;
+    border-width: 1px;
+  }
 </style>
 
 {#if builds.length === 0}
@@ -122,44 +129,33 @@
       Unscannable Links:
     </span>
     {#if !hiddenRows}
-      <span class="font-bold mb-3">
+      <span class="mb-3">
         Some working links are reported as broken by CodeAuditor. They're marked as "unscannable". <a class="link hover:text-red-600" href="https://github.com/SSWConsulting/SSW.CodeAuditor/wiki/SSW-CodeAuditor-Knowledge-Base-(KB)#known-websites-that-has-anti-web-scraping-measures">Learn more on our KB.</a>
       </span>
-      <table
-      class="table-fixed w-full md:table-auto mb-8"
-      in:fade={{ y: 100, duration: 400 }}
-      out:fade={{ y: -100, duration: 200 }}>
-      <thead>
-        <tr>
-          <th class="w-3/12 px-4 py-2">Unscannable Link</th>
-          <th class="w-3/12 px-4 py-2">Source</th>
-          <th class="hidden md:table-cell w-3/12 px-4 py-2">Anchor Text</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each foundUnscannableLinks as url}
-          <tr>
-            <td class="w-3/12 border px-4 py-2 break-all">
-              <a
-                class="inline-block align-baseline link md:truncate"
-                target="_blank"
-                href={url.dst}>
-                {url.dst.length < 70 ? url.dst : url.dst.substring(0, 70) + '...'}
-              </a>
-            </td>
-            <td class="w-3/12 border px-4 py-2 break-all">
-              <a
-                class="inline-block align-baseline link md:truncate"
-                target="_blank"
-                href={url.src}>
-                {url.src.length < 70 ? url.src : url.src.substring(0, 70) + '...'}
-              </a>
-            </td>
-            <td class="hidden md:table-cell w-3/12 border px-4 py-2 break-all">{url.link || ''}</td>
-          </tr>
-          {/each}
-        </tbody>
-      </table>
+      {#each foundUnscannableLinks as url}
+        <table 
+          class="table-fixed w-full md:table-auto mb-8"
+          in:fade={{ y: 100, duration: 400 }}
+          out:fade={{ y: -100, duration: 200 }}>
+          <tbody>
+            <tr>
+              <th class="table-header hidden md:table-cell w-2/12 px-4 py-2">Source</th>
+              <td class="w-10/12 border px-4 py-2 break-all">
+                <a class="inline-block align-baseline link md:truncate" target="_blank" href={url.src}>{url.src.length < 70 ? url.src : url.src.substring(0, 70) + '...'}</a>
+              </td> 
+            </tr>
+          
+            <tr>
+              <th class="table-header hidden md:table-cell w-2/12 px-4 py-2">Anchor Text</th>
+              <td class="hidden md:table-cell w-10/12 border px-4 py-2 break-all">{url.link || ''}</td>
+            </tr>
+            <tr>
+              <th class="table-header w-2/12 px-4 py-2">Unscannable Link</th> 
+              <td class="w-10/12 border px-4 py-2 break-all"><a class="inline-block align-baseline link md:truncate" target="_blank" href={url.dst}>{url.dst.length < 70 ? url.dst : url.dst.substring(0, 70) + '...'}</a></td>    
+            </tr>
+          </tbody>
+        </table>
+      {/each}
     {/if}
   {/if}
 

--- a/ui/src/components/linkauditorcomponents/DetailsTable.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsTable.svelte
@@ -141,7 +141,7 @@
             <tr>
               <th class="table-header hidden md:table-cell w-2/12 px-4 py-2">Source</th>
               <td class="w-10/12 border px-4 py-2 break-all">
-                <a class="inline-block align-baseline link md:truncate" target="_blank" href={url.src}>{url.src.length < 70 ? url.src : url.src.substring(0, 70) + '...'}</a>
+                <a class="inline-block align-baseline link" target="_blank" href={url.src}>{url.src}</a>
               </td> 
             </tr>
           
@@ -151,7 +151,9 @@
             </tr>
             <tr>
               <th class="table-header w-2/12 px-4 py-2">Unscannable Link</th> 
-              <td class="w-10/12 border px-4 py-2 break-all"><a class="inline-block align-baseline link md:truncate" target="_blank" href={url.dst}>{url.dst.length < 70 ? url.dst : url.dst.substring(0, 70) + '...'}</a></td>    
+              <td class="w-10/12 border px-4 py-2 break-all">
+                <a class="inline-block align-baseline link" target="_blank" href={url.dst}>{url.dst}</a>
+              </td>    
             </tr>
           </tbody>
         </table>

--- a/ui/src/components/linkauditorcomponents/DetailsTable.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsTable.svelte
@@ -119,12 +119,11 @@
             <path d="M9 5l7 7-7 7" />
           {/if}
         </Icon>
-      Found Unscannable Links:
+      Unscannable Links:
     </span>
     {#if !hiddenRows}
       <span class="font-bold mb-3">
-        See our <a class="link hover:text-red-600" href="https://github.com/SSWConsulting/SSW.CodeAuditor/wiki/SSW-CodeAuditor-Knowledge-Base-(KB)#known-websites-that-has-anti-web-scraping-measures">Knowledge Base (KB)</a> to learn more about 
-        why some working websites are reported as broken in CodeAuditor?
+        Some working links are reported as broken by CodeAuditor. They're marked as "unscannable". <a class="link hover:text-red-600" href="https://github.com/SSWConsulting/SSW.CodeAuditor/wiki/SSW-CodeAuditor-Knowledge-Base-(KB)#known-websites-that-has-anti-web-scraping-measures">Learn more on our KB.</a>
       </span>
       <table
       class="table-fixed w-full md:table-auto mb-8"

--- a/ui/src/components/linkauditorcomponents/DetailsTable.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsTable.svelte
@@ -141,7 +141,7 @@
             <tr>
               <th class="table-header md:table-cell w-2/12 px-4 py-2">Source</th>
               <td class="w-10/12 border px-4 py-2 break-all">
-                <a class="inline-block align-baseline link" target="_blank" href={url.src}>{url.src + 'sdfwdfdsfdsdfdsdfddsdfsdfsffsdfd'}</a>
+                <a class="inline-block align-baseline link" target="_blank" href={url.src}>{url.src}</a>
               </td> 
             </tr>
           

--- a/ui/src/components/linkauditorcomponents/DetailsTable.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsTable.svelte
@@ -35,7 +35,7 @@
     }
   });
 
-  let hiddenRows = false;
+  let hiddenRows = true;
   const hideShow = () => {
     hiddenRows = !hiddenRows
   }

--- a/ui/src/components/linkauditorcomponents/DetailsTable.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsTable.svelte
@@ -139,18 +139,18 @@
           out:fade={{ y: -100, duration: 200 }}>
           <tbody>
             <tr>
-              <th class="table-header hidden md:table-cell w-2/12 px-4 py-2">Source</th>
+              <th class="table-header md:table-cell w-4/12 md:w-2/12 px-4 py-2">Source</th>
               <td class="w-10/12 border px-4 py-2 break-all">
-                <a class="inline-block align-baseline link" target="_blank" href={url.src}>{url.src}</a>
+                <a class="inline-block align-baseline link" target="_blank" href={url.src}>{url.src + 'sdfwdfdsfdsdfdsdfddsdfsdfsffsdfd'}</a>
               </td> 
             </tr>
           
             <tr>
-              <th class="table-header hidden md:table-cell w-2/12 px-4 py-2">Anchor Text</th>
-              <td class="hidden md:table-cell w-10/12 border px-4 py-2 break-all">{url.link || ''}</td>
+              <th class="table-header md:table-cell w-4/12 md:w-2/12 px-4 py-2">Anchor Text</th>
+              <td class="md:table-cell w-10/12 border px-4 py-2 break-all">{url.link || ''}</td>
             </tr>
             <tr>
-              <th class="table-header w-2/12 px-4 py-2">Unscannable Link</th> 
+              <th class="table-header w-4/12 md:w-2/12 px-4 py-2">Unscannable Link</th> 
               <td class="w-10/12 border px-4 py-2 break-all">
                 <a class="inline-block align-baseline link" target="_blank" href={url.dst}>{url.dst}</a>
               </td>    


### PR DESCRIPTION
#438 

This implements @tiagov8's suggested changes for the Unscannable Links section.

<img width="1011" alt="Screenshot 2023-08-15 at 9 36 36 am" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/5df3614a-53d0-473f-b5f1-b10c949ba574">

**Figure: New UI for the Unscannable Links section from this PR**