### PR TITLE
Implement React rule preset

### DIFF
--- a/ui/src/components/htmlhintcomponents/UpdateHTMLRules.svelte
+++ b/ui/src/components/htmlhintcomponents/UpdateHTMLRules.svelte
@@ -102,7 +102,7 @@
 <Modal
   bind:show
   bind:loading={saving}
-  header="Enabled Rules:"
+  header="Enable/Disable Rules:"
   mainAction="Save"
   on:action={updateCustomHtmlRules}
   on:dismiss={dismiss}>

--- a/ui/src/components/htmlhintcomponents/UpdateHTMLRules.svelte
+++ b/ui/src/components/htmlhintcomponents/UpdateHTMLRules.svelte
@@ -22,6 +22,9 @@
   let htmlHintSelectedRules = []
   let customHtmlHintSelectedRules = []
 
+  $: htmlHintSelectedRules, handleSelectionChange();
+  $: customHtmlHintSelectedRules, handleSelectionChange();
+
   const dispatch = createEventDispatcher();
   const updateHtmlRules = () => dispatch("updateHtmlRules");
   
@@ -60,6 +63,23 @@
     }));
   };
 
+  const getPresetSelections = (presetName) => {
+    const preset = rulePresets.find((preset) => preset.name === presetName);
+    const isWhitelist = preset.type === PresetType.Whitelist;
+    return [
+      ...htmlHintSelectedRules.filter((rule) => {
+        return isWhitelist
+          ? preset.rules.includes(rule.rule)
+          : !preset.rules.includes(rule.rule)
+      }).map((rule) => rule.rule),
+      ...customHtmlHintSelectedRules.filter((rule) => {
+        return isWhitelist
+          ? preset.rules.includes(rule.rule)
+          : !preset.rules.includes(rule.rule)
+      }).map((rule) => rule.rule),
+    ]
+  }
+ 
   const deselectAllRules = () => {
     htmlHintSelectedRules = htmlHintSelectedRules.map(rule => ({...rule, isChecked: false}))
     customHtmlHintSelectedRules = customHtmlHintSelectedRules.map(rule => ({...rule, isChecked: false}))
@@ -115,6 +135,23 @@
       presetSelection = [value];
       selectPreset(value);
     }
+  };
+
+  const handleSelectionChange = () => {
+    let selection = [];
+
+    for (let i = 0; i < rulePresets.length; i++) {
+      const presetName = rulePresets[i].name;
+      const presetSelections = getPresetSelections(presetName);
+      const selectedRules = getSelectedRules();
+
+      if (JSON.stringify(presetSelections) === JSON.stringify(selectedRules)) {
+        selection = [presetName];
+        break;
+      }
+    }
+
+    presetSelection = selection;
   };
   
 </script>

--- a/ui/src/components/htmlhintcomponents/UpdateHTMLRules.svelte
+++ b/ui/src/components/htmlhintcomponents/UpdateHTMLRules.svelte
@@ -1,6 +1,6 @@
 <script>
   import Toastr from "../misccomponents/Toastr.svelte";
-  import { CONSTS, htmlHintRules, customHtmlHintRules, RuleType } from "../../utils/utils";
+  import { CONSTS, htmlHintRules, customHtmlHintRules, RuleType, rulePresets, PresetType } from "../../utils/utils";
   import Modal from "../misccomponents//Modal.svelte";
   import LoadingFlat from "../misccomponents/LoadingFlat.svelte";
   import { onMount, createEventDispatcher } from "svelte";
@@ -16,11 +16,7 @@
   let addedSuccess;
   let addedFail;
 
-	let selection = [];
-
-  let selectOption = []
-
-  $: selectOption, selectOption[0] === true ? selectAllRules() : deselectAllRules()
+  let presetSelection = [];
   
   // Check all selected htmlhint rules
   let htmlHintSelectedRules = []
@@ -46,29 +42,41 @@
     }
   })
 
-  const selectAllRules = () => {
-    htmlHintSelectedRules = htmlHintSelectedRules.map(rule => ({...rule, isChecked: true}))
-    customHtmlHintSelectedRules = customHtmlHintSelectedRules.map(rule => ({...rule, isChecked: true}))
+  const selectPreset = (presetName) => {
+    const preset = rulePresets.find((preset) => preset.name === presetName);
+    const isWhitelist = preset.type === PresetType.Whitelist;
 
-    htmlHintSelectedRules.forEach(htmlRule => {
-      selection.push(htmlRule.rule)
-    })
-
-    customHtmlHintSelectedRules.forEach(customRule => {
-      selection.push(customRule.rule)
-    })
-  }
+    htmlHintSelectedRules = htmlHintSelectedRules.map((rule) => ({
+      ...rule,
+      isChecked: isWhitelist
+        ? preset.rules.includes(rule.rule)
+        : !preset.rules.includes(rule.rule),
+    }));
+    customHtmlHintSelectedRules = customHtmlHintSelectedRules.map((rule) => ({
+      ...rule,
+      isChecked: isWhitelist
+        ? preset.rules.includes(rule.rule)
+        : !preset.rules.includes(rule.rule),
+    }));
+  };
 
   const deselectAllRules = () => {
     htmlHintSelectedRules = htmlHintSelectedRules.map(rule => ({...rule, isChecked: false}))
     customHtmlHintSelectedRules = customHtmlHintSelectedRules.map(rule => ({...rule, isChecked: false}))
-    selection = []
-  }
-  
+  };
+
+  const getSelectedRules = () => {
+    return [
+      ...htmlHintSelectedRules.filter((rule) => rule.isChecked).map((rule) => rule.rule),
+      ...customHtmlHintSelectedRules.filter((rule) => rule.isChecked).map((rule) => rule.rule),
+    ];
+  };
+
   const dismiss = () => (show = false);
 
   const updateCustomHtmlRules = async () => {
-    const selectedRules = selection.toString()
+    const selection = getSelectedRules();
+    const selectedRules = selection.toString();
     saving = true;
     if (selection.length > 0) {
       const res = await fetch(
@@ -96,6 +104,18 @@
       saving = false
     }
   };
+
+  const handlePresetInput = (event) => {
+    const value = event.target.value;
+
+    if (presetSelection[0] === value) {
+      presetSelection = [];
+      deselectAllRules();
+    } else {
+      presetSelection = [value];
+      selectPreset(value);
+    }
+  };
   
 </script>
 
@@ -110,14 +130,24 @@
     <LoadingFlat />
   {:else}
     <!-- else content here -->
-    <label>
-      <input type="checkbox" bind:group={selectOption} value={true}/>
-      <p class="inline-block align-baseline">Select All</p>
-    </label>
+    <div class="option">
+      {#each rulePresets as presetOption, index}
+        <label class="inline-block mr-2">
+          <input type="checkbox"
+            name="presets"
+            value={presetOption.name}
+            id="option{index}"
+            on:input={handlePresetInput}
+            bind:group={presetSelection}
+          >
+          <p class="inline-block align-baseline">{presetOption.name}</p>
+        </label>
+      {/each}
+    </div>
     <h3 class="font-bold">HTML Hint Rules: </h3>
     {#each htmlHintSelectedRules as rule}
       <label>
-        <input type="checkbox" bind:group={selection} bind:checked={rule.isChecked} value={rule.rule} /> 
+        <input type="checkbox" bind:checked={rule.isChecked} value={rule.rule} /> 
           <a 
           class="inline-block align-baseline link" 
           href="https://htmlhint.com/docs/user-guide/rules/{rule.rule}">
@@ -130,7 +160,7 @@
     <h3 class="font-bold">Custom HTML Rules: </h3>
     {#each customHtmlHintSelectedRules as rule}
       <label>
-        <input type="checkbox" bind:group={selection} bind:checked={rule.isChecked} value={rule.rule} /> 
+        <input type="checkbox" bind:checked={rule.isChecked} value={rule.rule} /> 
           <a 
           class="{rule.ruleLink ? 'link' : 'hover:no-underline cursor-text'} inline-block align-baseline" 
           href={rule.ruleLink}>

--- a/ui/src/components/summaryitemcomponents/CardSummary.svelte
+++ b/ui/src/components/summaryitemcomponents/CardSummary.svelte
@@ -87,7 +87,7 @@
         on:click={htmlHintThreshold}
         class="bgred hover:bg-red-800 text-white font-semibold py-2 px-4
         border hover:border-transparent rounded">
-        <span class="ml-2">Enabled Rules</span>
+        <span class="ml-2">Enable/Disable Rules</span>
       </button>
   {/if}
   </div>

--- a/ui/src/containers/HowItWorks.svelte
+++ b/ui/src/containers/HowItWorks.svelte
@@ -121,9 +121,9 @@
   
   const customRuleConfig = `
   ## How to Use Custom HTML Rules Configuration
-  #### 1. Click on "Enabled Rules" 
+  #### 1. Click on "Enable/Disable Rules" 
   ![image](https://user-images.githubusercontent.com/67776356/229018349-ab11cb85-1650-41c5-b3e5-af3e81a53bc0.png)
-  **Figure: Enabled Rules button**
+  **Figure: Enable/Disable Rules button**
 
   #### 2. Select which custom rules you want for your next scan  
   ![Image](https://github.com/SSWConsulting/SSW.CodeAuditor/assets/67776356/f6d09566-0ff8-4ef8-a120-53fade615689)

--- a/ui/src/containers/HtmlHints.svelte
+++ b/ui/src/containers/HtmlHints.svelte
@@ -177,6 +177,7 @@
   bind:show={htmlHintRulesShown}
   user={$userSession$}
   htmlRules={null}
+  threshold={null}
   on:updateHtmlRules={() => getSelectedHtmlRules()}
   />
 {/if}

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -600,6 +600,16 @@ export const rulePresets = [
   {
     name: 'React project',
     type: PresetType.Blacklist,
-    rules: []
+    rules: [
+      "attr-lowercase",
+      "style-disabled",
+      "head-script-disabled",
+      "inline-style-disabled",
+      "figure-must-use-the-right-code",
+      "alt-require",
+      "attr-value-not-empty",
+      "spec-char-escape",
+      "use-unicode-hex-code-for-special-html-characters"
+    ]
   },
 ];

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -585,3 +585,21 @@ export const customHtmlHintRules = [
   },
   // Add new rule id below
 ];
+
+export const PresetType = {
+  Whitelist: "Whitelist",
+  Blacklist: "Blacklist",
+};
+
+export const rulePresets = [
+  { 
+    name: 'Select All',
+    type: PresetType.Blacklist,
+    rules: []
+  },
+  {
+    name: 'React project',
+    type: PresetType.Whitelist,
+    rules: ["tagname-lowercase", "tag-pair", "meta-tag-must-not-redirect"]
+  },
+];

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -599,7 +599,7 @@ export const rulePresets = [
   },
   {
     name: 'React project',
-    type: PresetType.Whitelist,
-    rules: ["tagname-lowercase", "tag-pair", "meta-tag-must-not-redirect"]
+    type: PresetType.Blacklist,
+    rules: []
   },
 ];


### PR DESCRIPTION
#365

Adds a way to set up rule presets, with React rules included here.

Also adds some reactivity to the Select All and preset checkboxes, so they are kept in sync with the selected preset (i.e. if Select All is selected and then individual rules get deselected, Select All will no longer be ticked).

<img width="1158" alt="Screenshot 2023-08-14 at 12 20 15 pm" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/9affe94f-679c-492c-940d-f37a34f4a996">
Figure: New React presets
