### PR TITLE
Request GET for unscannable links in Link Auditor

### DIFF
--- a/docker/sswlinkauditor.go
+++ b/docker/sswlinkauditor.go
@@ -206,38 +206,38 @@ func writeResultFile(allUrls map[string]LinkStatus) {
 }
 
 func isLinkUnscannable(a string) bool {
-	unscannableLinks := []string{
-		"https://learn.microsoft.com/en-us/",
-        "https://support.google.com/",
-        "https://twitter.com/",
-        "https://marketplace.visualstudio.com/",
-        "https://www.nuget.org/",
-        "https://make.powerautomate.com",
-        "https://www.microsoft.com/",
-        "http://www.microsoft.com/",
-        "https://answers.microsoft.com/",
-        "https://admin.microsoft.com/",
-        "https://ngrx.io",
-        "https://twitter.com",
-        "https://marketplace",
-        "https://www.nuget.org/",
-        "http://nuget.org",
-        "https://t.co",
-        "https://support.google.com",
-        "https://playwright.dev",
-        "https://www.theurlist.com/xamarinstreamers",
-        "https://dev.botframework.com",
-        "https://www.ssw.com.au/rules/rules-to-better-research-and-development/",
-        "https://www.ato.gov.au/Business/Research-and-development-tax-incentive/",
-        "https://learn.microsoft.com/en-us/assessments/?mode=home/",
-	}
-
     for _, b := range unscannableLinks {
         if strings.HasPrefix(strings.ToLower(a), strings.ToLower(b)) {
             return true
         }
     }
     return false
+}
+
+var unscannableLinks = []string{
+	"https://learn.microsoft.com/en-us/",
+	"https://support.google.com/",
+	"https://twitter.com/",
+	"https://marketplace.visualstudio.com/",
+	"https://www.nuget.org/",
+	"https://make.powerautomate.com",
+	"https://www.microsoft.com/",
+	"http://www.microsoft.com/",
+	"https://answers.microsoft.com/",
+	"https://admin.microsoft.com/",
+	"https://ngrx.io",
+	"https://twitter.com",
+	"https://marketplace",
+	"https://www.nuget.org/",
+	"http://nuget.org",
+	"https://t.co",
+	"https://support.google.com",
+	"https://playwright.dev",
+	"https://www.theurlist.com/xamarinstreamers",
+	"https://dev.botframework.com",
+	"https://www.ssw.com.au/rules/rules-to-better-research-and-development/",
+	"https://www.ato.gov.au/Business/Research-and-development-tax-incentive/",
+	"https://learn.microsoft.com/en-us/assessments/?mode=home/",
 }
 
 func main() {

--- a/docker/sswlinkauditor.go
+++ b/docker/sswlinkauditor.go
@@ -206,12 +206,12 @@ func writeResultFile(allUrls map[string]LinkStatus) {
 }
 
 func isLinkUnscannable(a string) bool {
-    for _, b := range unscannableLinks {
-        if strings.HasPrefix(strings.ToLower(a), strings.ToLower(b)) {
-            return true
-        }
-    }
-    return false
+	for _, b := range unscannableLinks {
+		if strings.HasPrefix(strings.ToLower(a), strings.ToLower(b)) {
+			return true
+		}
+	}
+	return false
 }
 
 var unscannableLinks = []string{

--- a/docker/sswlinkauditor.go
+++ b/docker/sswlinkauditor.go
@@ -48,7 +48,6 @@ func check(link Link, linkch chan LinkStatus, number int) {
 	client := &http.Client{}
 	method := "HEAD"
 
-
 	if isLinkUnscannable(link.url) {
 		method = "GET"
 	}

--- a/docker/sswlinkauditor.go
+++ b/docker/sswlinkauditor.go
@@ -46,7 +46,14 @@ func check(link Link, linkch chan LinkStatus, number int) {
 	fmt.Println("CHEC", number, link.url)
 
 	client := &http.Client{}
-	r, e := http.NewRequest("HEAD", link.url, nil)
+	method := "HEAD"
+
+
+	if isLinkUnscannable(link.url) {
+		method = "GET"
+	}
+
+	r, e := http.NewRequest(method, link.url, nil)
 
 	if e != nil {
 		linkch <- LinkStatus{link.url, link.srcUrl, "Link Invalid", 0, link.anchor}
@@ -196,6 +203,41 @@ func writeResultFile(allUrls map[string]LinkStatus) {
 	}
 
 	f.Close()
+}
+
+func isLinkUnscannable(a string) bool {
+	unscannableLinks := []string{
+		"https://learn.microsoft.com/en-us/",
+        "https://support.google.com/",
+        "https://twitter.com/",
+        "https://marketplace.visualstudio.com/",
+        "https://www.nuget.org/",
+        "https://make.powerautomate.com",
+        "https://www.microsoft.com/",
+        "http://www.microsoft.com/",
+        "https://answers.microsoft.com/",
+        "https://admin.microsoft.com/",
+        "https://ngrx.io",
+        "https://twitter.com",
+        "https://marketplace",
+        "https://www.nuget.org/",
+        "http://nuget.org",
+        "https://t.co",
+        "https://support.google.com",
+        "https://playwright.dev",
+        "https://www.theurlist.com/xamarinstreamers",
+        "https://dev.botframework.com",
+        "https://www.ssw.com.au/rules/rules-to-better-research-and-development/",
+        "https://www.ato.gov.au/Business/Research-and-development-tax-incentive/",
+        "https://learn.microsoft.com/en-us/assessments/?mode=home/",
+	}
+
+    for _, b := range unscannableLinks {
+        if strings.HasPrefix(strings.ToLower(a), strings.ToLower(b)) {
+            return true
+        }
+    }
+    return false
 }
 
 func main() {


### PR DESCRIPTION
#574 

In our link auditing code, this now first checks if a given URL is included in our Unscannable Links list. If it is, it checks the link using a GET request to give us a more accurate response for certain links. If it isn't, it uses the standard HEAD request.