### PR TITLE
Improve HTML Rules Scanned UI

### DIFF
--- a/ui/src/components/htmlhintcomponents/HTMLHintDetailsCard.svelte
+++ b/ui/src/components/htmlhintcomponents/HTMLHintDetailsCard.svelte
@@ -3,7 +3,7 @@
   import CodeSummary from "../summaryitemcomponents/CodeSummary.svelte";
   import LinkSummary from "../summaryitemcomponents/LinkSummary.svelte";
   import ArtillerySummary from "../summaryitemcomponents/ArtillerySummary.svelte";
-  import { htmlHintRules, customHtmlHintRules } from "../../utils/utils";
+  import { htmlHintRules, customHtmlHintRules, RuleType } from "../../utils/utils";
 
   export let build = {};
   export let htmlRules;
@@ -83,16 +83,26 @@
               <div class="ml-3">
                 {#if customHtmlHintRules.some(x => x.rule === rule)}
                   <a
+                    target="_blank"
                     class="{(customHtmlHintRules.find(x => x.rule === rule)).ruleLink ? 'link' : 'hover:no-underline cursor-text'} inline-block align-baseline"  
                     href="{(customHtmlHintRules.find(x => x.rule === rule)).ruleLink}"
                   >
+                    <i 
+                      class="{customHtmlHintRules.find(x => x.rule === rule).type === RuleType.Error ? 'fas fa-exclamation-circle fa-md' : 'fas fa-exclamation-triangle fa-md'}"
+                      style="{customHtmlHintRules.find(x => x.rule === rule).type === RuleType.Error ? 'color: red' : 'color: #d69e2e'}"
+                    ></i> 
                     {customHtmlHintRules.find(x => x.rule === rule).displayName}
                   </a>
                 {:else if htmlHintRules.some(x => x.rule === rule)}
                   <a 
+                    target="_blank"
                     class="{(htmlHintRules.find(x => x.rule === rule)).ruleLink ? 'link' : 'hover:no-underline cursor-text'} inline-block align-baseline"  
                     href="{(htmlHintRules.find(x => x.rule === rule)).ruleLink}"
                   >
+                    <i
+                      class="{htmlHintRules.find(x => x.rule === rule).type === RuleType.Error ? 'fas fa-exclamation-circle fa-md' : 'fas fa-exclamation-triangle fa-md'}"
+                      style="{htmlHintRules.find(x => x.rule === rule).type === RuleType.Error ? 'color: red' : 'color: #d69e2e'}"
+                    ></i>
                     {htmlHintRules.find(x => x.rule === rule).displayName}
                   </a>
                 {/if}

--- a/ui/src/components/htmlhintcomponents/UpdateHTMLRules.svelte
+++ b/ui/src/components/htmlhintcomponents/UpdateHTMLRules.svelte
@@ -33,20 +33,20 @@
   })
 
   const initSelectedRules = () => {
-    if (htmlRules) {
-      let selectedHTMLRules = htmlRules.selectedRules.split(/[,]+/)
-      htmlHintSelectedRules = htmlHintRules.map(htmlRule => ({...htmlRule, isChecked: selectedHTMLRules.includes(htmlRule.rule)}))
-      customHtmlHintSelectedRules = customHtmlHintRules.map(htmlRule => ({...htmlRule, isChecked: selectedHTMLRules.includes(htmlRule.rule)}))
+    if (threshold?.selectedRules) {
+      setSelectedRules(threshold?.selectedRules);
+    } else if (htmlRules?.selectedRules) {
+      setSelectedRules(htmlRules?.selectedRules);
     } else {
-      if (threshold) {
-        let selectedHTMLRules = threshold.selectedRules.split(/[,]+/)
-        htmlHintSelectedRules = htmlHintRules.map(htmlRule => ({...htmlRule, isChecked: selectedHTMLRules.includes(htmlRule.rule)}))
-        customHtmlHintSelectedRules = customHtmlHintRules.map(htmlRule => ({...htmlRule, isChecked: selectedHTMLRules.includes(htmlRule.rule)}))
-      } else {
-        htmlHintSelectedRules = htmlHintRules.map(htmlRule => ({...htmlRule, isChecked: true}))
-        customHtmlHintSelectedRules = customHtmlHintRules.map(htmlRule => ({...htmlRule, isChecked: true}))
-      }
+      htmlHintSelectedRules = htmlHintRules.map(htmlRule => ({...htmlRule, isChecked: true}))
+      customHtmlHintSelectedRules = customHtmlHintRules.map(htmlRule => ({...htmlRule, isChecked: true}))
     }
+  };
+
+  const setSelectedRules = (rulesString) => {
+    let selectedHTMLRules = rulesString.split(/[,]+/);
+    htmlHintSelectedRules = htmlHintRules.map(htmlRule => ({...htmlRule, isChecked: selectedHTMLRules.includes(htmlRule.rule)}));
+    customHtmlHintSelectedRules = customHtmlHintRules.map(htmlRule => ({...htmlRule, isChecked: selectedHTMLRules.includes(htmlRule.rule)}));
   };
 
   const selectPreset = (presetName) => {
@@ -193,6 +193,7 @@
       <label>
         <input type="checkbox" bind:checked={rule.isChecked} value={rule.rule} /> 
           <a 
+          target="_blank"
           class="inline-block align-baseline link" 
           href="https://htmlhint.com/docs/user-guide/rules/{rule.rule}">
             <i class="{rule.type === RuleType.Error ? 'fas fa-exclamation-circle fa-md' : 'fas fa-exclamation-triangle fa-md'}" style="{rule.type === RuleType.Error ? 'color: red' : 'color: #d69e2e'}"></i> 
@@ -206,6 +207,7 @@
       <label>
         <input type="checkbox" bind:checked={rule.isChecked} value={rule.rule} /> 
           <a 
+          target="_blank"
           class="{rule.ruleLink ? 'link' : 'hover:no-underline cursor-text'} inline-block align-baseline" 
           href={rule.ruleLink}>
             <i class="{rule.type === RuleType.Error ? 'fas fa-exclamation-circle fa-md' : 'fas fa-exclamation-triangle fa-md'}" style="{rule.type === RuleType.Error ? 'color: red' : 'color: #d69e2e'}"></i> 


### PR DESCRIPTION
#599

Improves the UI in the HTML Rules Scanned section to include the same icons as found in the Enable/Disable Rules modal.

Also tidies up the code in the modal section slightly.

<img width="561" alt="Screenshot 2023-08-22 at 4 11 34 pm" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/362abd22-2c3c-42c1-96cb-327a0ea0f5c8">

**Figure: Improved HTML Rules Scanned section with icons**