### PR TITLE
Fix TypeError when expanding scan history on Explore page

### DIFF
--- a/ui/src/components/buildlistcardcomponents/BuildList.svelte
+++ b/ui/src/components/buildlistcardcomponents/BuildList.svelte
@@ -25,11 +25,14 @@
   function toggle(n) {
     currCard = n;
     showTotalBuild = !showTotalBuild;
-    var x = document.getElementById("detailCard");
-    if (x.style.display === "none") {
-      x.style.display = "block";
-    } else {
-      x.style.display = "none";
+    const x = document.getElementById("detailCard");
+
+    if (x) {
+      if (x.style.display === "none") {
+        x.style.display = "block";
+      } else {
+        x.style.display = "none";
+      }
     }
   }
 </script>


### PR DESCRIPTION
This is just a quick bugfix for an error that appears in the console when expanding the Scan History on a site on the Explore page.

<img width="1278" alt="Screenshot 2023-08-25 at 11 41 22 am" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/a1b6d84d-7da3-4b82-ac82-4a90349e5587">

**Figure: Error in console**