### PR TITLE
Hide sign up section when logged in

### DIFF
--- a/ui/src/containers/Home.svelte
+++ b/ui/src/containers/Home.svelte
@@ -1,5 +1,6 @@
 <script>
   import { navigateTo } from "svelte-router-spa";
+  import { isLoggedIn } from "../stores.js";
 </script>
 
 <div class="container mx-auto">
@@ -24,6 +25,7 @@
     </div>
   </section>
 
+  {#if !$isLoggedIn}
   <section class="text-gray-700 body-font">
     <div
       class="container mx-auto flex px-5 pb-20 pt-15 items-center justify-center
@@ -53,6 +55,7 @@
       </div>
     </div>
   </section>
+  {/if}
 
   <section class="text-gray-700 body-font">
     <div


### PR DESCRIPTION
#607

This hides the Sign Up section on the home page if the user is signed in.

<img width="1281" alt="Screenshot 2023-08-25 at 4 26 32 pm" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/87f9c3dd-e92c-458d-801f-84550e9ab43e">

**Figure: Sign Up section is hidden when logged in**