### PR TITLE
Fixed missing code warning/error properties

### DIFF
--- a/api/functions/index.js
+++ b/api/functions/index.js
@@ -263,8 +263,8 @@ app.post('/scanresult/:api/:buildId', async (req, res) => {
 			R.prop('dst'),
 			badUrls.filter((x) => x.statuscode === '404' && !unscannableLinks.some(link => x.dst.includes(link.url)))
 		).length,
-		htmlWarnings,
-		htmlErrors,
+		htmlWarnings: htmlWarnings,
+		htmlErrors: htmlErrors,
 		codeIssues: getCodeErrorSummary(code),
 		htmlIssuesList,
 		isPrivate,


### PR DESCRIPTION
When code errors or warning is 0 or null, its property field is not added to Azure Table