### PR TITLE
Fix console error on Scan Results page

### DIFF
--- a/ui/src/components/summaryitemcomponents/CardSummary.svelte
+++ b/ui/src/components/summaryitemcomponents/CardSummary.svelte
@@ -34,10 +34,12 @@
   onMount(async () => {
     // Check if scan has any previous scans
     userSession$.subscribe(async x => {
-      userApiKey = x.apiKey;
-      let fullUrl = convertSpecialCharUrl(value.url)
-      const res = await fetch(`${CONSTS.API}/api/scanSummaryFromUrl/${userApiKey}/${fullUrl}`);
-      previousScans = await res.json();
+      if (x) {
+        userApiKey = x.apiKey;
+        let fullUrl = convertSpecialCharUrl(value.url)
+        const res = await fetch(`${CONSTS.API}/api/scanSummaryFromUrl/${userApiKey}/${fullUrl}`);
+        previousScans = await res.json();
+      }
     });
   })
 


### PR DESCRIPTION
Small bugfix to fix a sporadic error on the Scan Results page. This just adds a basic null check before trying to set the apiKey.

<img width="595" alt="Screenshot 2023-08-29 at 5 35 36 pm" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/39513563-4ec1-4a98-8735-ab8863478df8">

**Figure: Error in console**