### PR TITLE
Fix query responses

### DIFF
--- a/api/functions/queries.js
+++ b/api/functions/queries.js
@@ -74,7 +74,7 @@ exports.getLoadThreshold = (api, url) =>
 		for await (const item of entity) {
 			result.push(item);
 		}
-		resolve(result)
+		resolve(result[0])
 	});
 
 exports.getHTMLHintRules = (api, url) => 
@@ -86,7 +86,7 @@ exports.getHTMLHintRules = (api, url) =>
 		for await (const item of entity) {
 			result.push(item);
 		}
-		resolve(result)
+		resolve(result[0])
   });
 
 exports.getHTMLHintRulesByRunId = (runId) => 
@@ -98,7 +98,7 @@ exports.getHTMLHintRulesByRunId = (runId) =>
 		for await (const item of entity) {
 			result.push(item);
 		}
-		resolve(result)
+		resolve(result[0])
 	});
 
 exports.getPersonalSummary = (api, showAll) =>


### PR DESCRIPTION
Quick bugfix to fix the queries returning arrays rather than the expected result. Fixes things like the HTML Hint rules list which are currently broken.