### PR TITLE
Show broken link age on Scan Results page

### DIFF
--- a/api/functions/queries.js
+++ b/api/functions/queries.js
@@ -46,7 +46,7 @@ exports.getScanDetails = async (runId) => {
     }
     const previousFailures = new Map();
 
-    const filtered = result.reduce((acc, item) => {
+    const filteredList = result.reduce((runLinks, item) => {
         if (item.runId === runId) {
             let daysUnfixed = -1;
 
@@ -62,15 +62,15 @@ exports.getScanDetails = async (runId) => {
                 daysUnfixed = getDateDifference(item.buildDate, firstUnfixed.buildDate);
             }
 
-            acc.push({
+            runLinks.push({
                 ...item,
                 daysUnfixed,
             });
         }
-        return acc;
+        return runLinks;
     }, []);
 
-    return filtered;
+    return filteredList;
 };
 
 exports.getIgnoredUrls = (api) =>

--- a/ui/src/components/linkauditorcomponents/DetailsByDest.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsByDest.svelte
@@ -24,6 +24,16 @@
   let hiddenRows = {};
   const hideShow = key =>
     (hiddenRows[key] = key in hiddenRows ? !hiddenRows[key] : true);
+
+  const formatDaysUnfixed = (daysNum) => {
+    if (daysNum === 0) {
+      return 'Unfixed for <1 day';
+    } else if (daysNum > 0) {
+      return `Unfixed for ${daysNum} days`;
+    } else {
+      return '';
+    }
+  };
 </script>
 
 {#each destinationsKeys as url}
@@ -65,10 +75,11 @@
         </Icon>
       </button>
     {/if}
-
   </div>
-
   {#if !hiddenRows[url]}
+    <span class="font-bold text-red-600">
+      {formatDaysUnfixed(destinations[url][0].daysUnfixed)}
+    </span>
     <table
       class="table-fixed w-full md:table-auto mb-8"
       in:fade={{ y: 100, duration: 400 }}

--- a/ui/src/components/linkauditorcomponents/DetailsByDest.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsByDest.svelte
@@ -77,9 +77,12 @@
     {/if}
   </div>
   {#if !hiddenRows[url]}
-    <span class="font-bold text-red-600">
+    {#if destinations[url][0].daysUnfixed > -1}
+    <div class="font-bold textgrey ml-2">
+      <i class="fas fa-exclamation-triangle"></i>
       {formatDaysUnfixed(destinations[url][0].daysUnfixed)}
-    </span>
+    </div>
+    {/if}
     <table
       class="table-fixed w-full md:table-auto mb-8"
       in:fade={{ y: 100, duration: 400 }}

--- a/ui/src/components/linkauditorcomponents/DetailsByReason.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsByReason.svelte
@@ -29,7 +29,7 @@
     } else if (daysNum > 0) {
       return daysNum.toString();
     } else {
-      return 'New';
+      return '-';
     }
   };
 </script>

--- a/ui/src/components/linkauditorcomponents/DetailsByReason.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsByReason.svelte
@@ -22,6 +22,16 @@
 
   const hideShow = key =>
     (hiddenRows[key] = key in hiddenRows ? !hiddenRows[key] : true);
+
+  const formatDaysUnfixed = (daysNum) => {
+    if (daysNum === 0) {
+      return '<1';
+    } else if (daysNum > 0) {
+      return daysNum.toString();
+    } else {
+      return 'New';
+    }
+  };
 </script>
 
 {#each reasonsKeys as reason}
@@ -43,15 +53,16 @@
 
   {#if !hiddenRows[reason]}
     <table
-      class="table-fixed w-full md:table-auto mb-8"
+      class="table-fixed w-full table-auto mb-8"
       in:fade={{ y: 100, duration: 400 }}
       out:fade={{ y: -100, duration: 200 }}>
       <thead>
         <tr>
           <th class="w-4/12 px-4 py-2">Source ({reasons[reason].length})</th>
-          <th class="w-5/12 px-4 py-2">Destination</th>
+          <th class="w-4/12 px-4 py-2">Destination</th>
           <th class="w-2/12 px-4 py-2">Anchor Text</th>
           <th class="w-1/12 px-4 py-2 text-right">Status</th>
+          <th class="w-1/12 px-4 py-2 text-right">Days Unfixed</th>
         </tr>
       </thead>
       <tbody>
@@ -65,7 +76,7 @@
                 {val.src}
               </a>
             </td>
-            <td class="w-5/12 border px-4 py-2">
+            <td class="w-4/12 border px-4 py-2 break-all">
               <a
                 class="inline-block align-baseline"
                 target="_blank"
@@ -100,6 +111,9 @@
             <td class="w-2/12 border px-4 py-2 break-all">{val.link || ''}</td>
             <td class="w-1/12 border px-4 py-2 text-right">
               {val.statuscode || '0'}
+            </td>
+            <td class="w-1/12 border px-4 py-2 text-right">
+              {formatDaysUnfixed(val.daysUnfixed)}
             </td>
           </tr>
         {/each}

--- a/ui/src/components/linkauditorcomponents/DetailsBySource.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsBySource.svelte
@@ -30,7 +30,7 @@
     } else if (daysNum > 0) {
       return daysNum.toString();
     } else {
-      return 'New';
+      return '-';
     }
   };
 </script>

--- a/ui/src/components/linkauditorcomponents/DetailsBySource.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsBySource.svelte
@@ -23,10 +23,20 @@
   let hiddenRows = {};
   const hideShow = key =>
     (hiddenRows[key] = key in hiddenRows ? !hiddenRows[key] : true);
+
+  const formatDaysUnfixed = (daysNum) => {
+    if (daysNum === 0) {
+      return '<1';
+    } else if (daysNum > 0) {
+      return daysNum.toString();
+    } else {
+      return 'New';
+    }
+  };
 </script>
 
 <style>
-  .truncate {
+  .truncate-link {
     width: 400px;
     white-space: nowrap;
     overflow: hidden;
@@ -54,15 +64,16 @@
   </div>
   {#if !hiddenRows[url]}
     <table
-      class="table-fixed w-full md:table-auto mb-8"
+      class="table-fixed w-full table-auto mb-8"
       in:fade={{ y: 100, duration: 400 }}
       out:fade={{ y: -100, duration: 200 }}>
       <thead>
         <tr>
           <th class="w-6/12 px-4 py-2">Broken Link ({sources[url].length})</th>
-          <th class="hidden md:table-cell w-3/12 px-4 py-2">Anchor Text</th>
+          <th class="hidden md:table-cell w-2/12 px-4 py-2">Anchor Text</th>
           <th class="w-1/12 px-4 py-2 text-right">Status</th>
           <th class="hidden md:table-cell w-2/12 px-4 py-2 text-right">Message</th>
+          <th class="hidden md:table-cell w-1/12 px-4 py-2 text-right">Days Unfixed</th>
         </tr>
       </thead>
       <tbody>
@@ -93,19 +104,22 @@
                 </button>
               {/if}
               <a
-                class="inline-block align-baseline link md:truncate"
+                class="inline-block align-baseline link md:truncate-link"
                 target="_blank"
                 href={val.dst}>
                 {val.dst.length < 70 ? val.dst : val.dst.substring(0, 70) + '...'}
               </a>
 
             </td>
-            <td class="hidden md:table-cell w-3/12 border px-4 py-2 break-all">{val.link || ''}</td>
+            <td class="hidden md:table-cell w-2/12 border px-4 py-2 break-all">{val.link || ''}</td>
             <td class="w-1/12 border px-4 py-2 text-right">
               {val.statuscode || '0'}
             </td>
             <td class="hidden md:table-cell w-2/12 border px-4 py-2 text-right">
               {val.statusmsg || ''}
+            </td>
+            <td class="hidden md:table-cell w-1/12 border px-4 py-2 text-right">
+              {formatDaysUnfixed(val.daysUnfixed)}
             </td>
           </tr>
         {/each}


### PR DESCRIPTION
#531 

This shows how long each link has been around when viewing a scan result. Adds a new table column for this info when viewing by Source and Status, and new text below each link when viewing by Destination