### PR TITLE
Fix scan history chart alignment

### DIFF
--- a/ui/src/components/buildlistcardcomponents/HistoryChart.svelte
+++ b/ui/src/components/buildlistcardcomponents/HistoryChart.svelte
@@ -103,7 +103,7 @@
   });
 </script>
 
-<div class="text-center">
+<div class="text-center whitespace-no-wrap">
   <span class="inline-block font-sans sm:text-sm">{chartTitle}</span>
   <svg
     class="inline-block w-6 h-6"


### PR DESCRIPTION
This is just a tiny bugfix to resolve an issue where the scan history charts can render misaligned due to the arrow wrapping to a new line.

<img width="1016" alt="Screenshot 2023-09-01 at 2 20 05 pm" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/6a38bea4-85ed-4701-ae47-92ff1a07c4fe">

**Figure: The charts can render misaligned due to the arrows wrapping**

<img width="1026" alt="Screenshot 2023-09-01 at 2 25 19 pm" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/efacef12-57d3-4649-b55f-8c9f370b1392">

**Figure: Should render correctly now**