### PR TITLE
Adjust underlines on Rules page

### DIFF
--- a/ui/src/containers/Rules.svelte
+++ b/ui/src/containers/Rules.svelte
@@ -4,9 +4,7 @@
 <style>
   .link, .text {
     color: black;
-    text-decoration: underline;
-    text-decoration-style: solid;
-    text-decoration-thickness: 1px;
+    text-decoration: solid underline 1px #aaa;
   }
 </style>
 <div class="container mx-auto">

--- a/ui/src/global.scss
+++ b/ui/src/global.scss
@@ -6,138 +6,135 @@
 
 html,
 body {
-	position: relative;
-	width: 100%;
-	height: 100%;
+  position: relative;
+  width: 100%;
+  height: 100%;
 }
 
 body {
-	color: #333;
-	margin: 0;
-	box-sizing: border-box;
-	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-		Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  color: #333;
+  margin: 0;
+  box-sizing: border-box;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
 }
 
 a {
-	text-decoration: none;
+  text-decoration: none;
 }
 
 a:hover {
-	text-decoration: underline;
+  text-decoration: underline;
 }
 
 label {
-	display: block;
+  display: block;
 }
 
 input,
 button,
 select,
 textarea {
-	font-family: inherit;
-	font-size: inherit;
-	padding: 0.4em;
-	margin: 0 0 0.5em 0;
-	box-sizing: border-box;
-	border: 1px solid #ccc;
-	border-radius: 2px;
+  font-family: inherit;
+  font-size: inherit;
+  padding: 0.4em;
+  margin: 0 0 0.5em 0;
+  box-sizing: border-box;
+  border: 1px solid #ccc;
+  border-radius: 2px;
 }
 
 input:disabled {
-	color: #ccc;
+  color: #ccc;
 }
 
 input[type='range'] {
-	height: 0;
+  height: 0;
 }
 
 button {
-	color: #333;
-	background-color: #f4f4f4;
-	outline: none;
+  color: #333;
+  outline: none;
+  margin: 0;
 }
 
 button:disabled {
-	color: #999;
+  color: #999;
 }
 
 button:not(:disabled):active {
-	background-color: #ddd;
+  background-color: #ddd;
 }
 
 button:focus {
-	border-color: #666;
+  border-color: #666;
 }
 
 .lh-sticky-header {
-	display: none !important;
+  display: none !important;
 }
 
 .bggrey {
-	background-color: #eee;
+  background-color: #eee;
 }
 
 .textgrey {
-	color: #797979;
+  color: #797979;
 }
 .bgdark {
-	background-color: #414141;
+  background-color: #414141;
 }
 .bggrey {
-	background-color: #e9e9e9;
+  background-color: #e9e9e9;
 }
 .borderdark {
-	border-color: #414141;
+  border-color: #414141;
 }
 .textred {
-	color: #cc4141;
+  color: #cc4141;
 }
 .bgred {
-	background-color: #cc4141;
+  background-color: #cc4141;
 }
 .textdark {
-	color: #333;
+  color: #333;
 }
 .link {
-    text-decoration: underline;
-    text-decoration-color: #aaa;
-    text-decoration-style: solid;
-    text-decoration-thickness: 1px;
-    transition: color .25s ease;
-    word-break: break-word;
+  text-decoration: solid underline 1px #aaa;
+  transition: color 0.25s ease;
+  word-break: break-word;
 }
 
 .link:hover {
-    color: #cc4141;
-    text-decoration-color: #cc4141;
+  color: #cc4141;
+  text-decoration-color: #cc4141;
 }
 
 .bordered {
-    border: 10px solid #eee;
-    outline: 1px solid #ccc;
+  border: 10px solid #eee;
+  outline: 1px solid #ccc;
 }
 
 /* Pace.js */
 .pace {
-	-webkit-pointer-events: none;
-	pointer-events: none;
+  -webkit-pointer-events: none;
+  pointer-events: none;
 
-	-webkit-user-select: none;
-	-moz-user-select: none;
-	user-select: none;
-  }
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
 
-  .pace-inactive {
-	display: none;
-  }
+.pace-inactive {
+  display: none;
+}
 
-  .pace .pace-progress {
-	background: #cc4141;
-	position: fixed;
-	z-index: 2000;
-	top: 0;
-	right: 100%;
-	width: 100%;
-	height: 2px;
-  }
+.pace .pace-progress {
+  background: #cc4141;
+  position: fixed;
+  z-index: 2000;
+  top: 0;
+  right: 100%;
+  width: 100%;
+  height: 2px;
+}


### PR DESCRIPTION
Small tweak to clean up the appearance of the link underlines on the Rules page so they appear less bold.

<img width="558" alt="Screenshot 2023-09-08 at 3 51 49 pm" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/6a4d34c6-e3cd-43fa-b52d-5f75c6767121">

**Figure: Link underlines are now less bold and match other links on the site**