### PR TITLE
Fixed scan compare queries

### DIFF
--- a/api/functions/index.js
+++ b/api/functions/index.js
@@ -172,8 +172,8 @@ app.get('/scanSummaryFromUrl/:api/:url', async (req, res) => {
 	res.json(await getAllScanSummaryFromUrl(req.params.url, req.params.api));
 });
 
-app.get('/comparescanlatestandsecond/:api/:url', async (req, res) => {
-	res.json(await compareScans(req.params.api, req.params.url));
+app.post('/comparescanlatestandsecond/:api', async (req, res) => {
+	res.json(await compareScans(req.params.api, req.body.url));
 });
 
 app.get('/unscannableLinks', async (req, res) => {

--- a/api/functions/package-lock.json
+++ b/api/functions/package-lock.json
@@ -14584,7 +14584,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"devOptional": true,
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -15527,6 +15527,20 @@
 			"dev": true,
 			"dependencies": {
 				"is-typedarray": "^1.0.0"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+			"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+			"dev": true,
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/uc.micro": {
@@ -28131,7 +28145,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"devOptional": true
+			"dev": true
 		},
 		"source-map-resolve": {
 			"version": "0.5.3",
@@ -28888,6 +28902,13 @@
 			"requires": {
 				"is-typedarray": "^1.0.0"
 			}
+		},
+		"typescript": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+			"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+			"dev": true,
+			"peer": true
 		},
 		"uc.micro": {
 			"version": "1.0.6",

--- a/api/functions/queries.js
+++ b/api/functions/queries.js
@@ -292,6 +292,9 @@ exports.compareScans = (api, url) =>
 		// Standardize url string
 		if (!url.startsWith("https://")) {
 			url = "https://" + url;
+		}
+		if (!url.startsWith("http://")) {
+			url = "http://" + url;
 		}  
 		if (!url.includes("www.")) {
 			url = url.replace('https://', 'https://www.');

--- a/api/functions/queries.js
+++ b/api/functions/queries.js
@@ -289,6 +289,17 @@ exports.getUnscannableLinks = () =>
 
 exports.compareScans = (api, url) =>
 	new Promise(async (resolve) => {
+		// Standardize url string
+		if (!url.startsWith("https://")) {
+			url = "https://" + url;
+		}  
+		if (!url.includes("www.")) {
+			url = url.replace('https://', 'https://www.');
+		} 
+		if (!url.endsWith("/")) {
+			url = url + '/';
+		}
+
 		const entity = new TableClient(azureUrl, TABLE.Scans, credential).listEntities({
 			queryOptions: { filter: odata`PartitionKey eq ${api} and url eq ${url}` }
 		});


### PR DESCRIPTION
- Getting Url data from `req.body` instead of `req.params` as parameter string does not work well with Urls that contains special characters such as `//` or `:` 
- Using Post instead of Get request for queries with body as Google Firebase would returns 400 (`Your client has issued a malformed or illegal request`) because POST is more secure and it's never cached
- Format Url string to match what's in the database