### PR TITLE
Fix token bug on How It Works page

### DIFF
--- a/ui/src/containers/HowItWorks.svelte
+++ b/ui/src/containers/HowItWorks.svelte
@@ -1,24 +1,53 @@
 <script>
   import { userSession$ } from "../stores";
   import marked from "marked";
-  import firebase from "firebase/compat/app";
-  import { CONSTS } from "../utils/utils.js";
-  
-  let unsubscription;
+  import { onDestroy } from "svelte";
 
-  let tokenText;
-  userSession$.subscribe((x) => {
+  let instruction, instructionSteps;
+
+  const unsubscribe = userSession$.subscribe((x) => {
     if (x) {
-      unsubscription = firebase
-          .firestore()
-          .collection(CONSTS.USERS)
-          .doc(x.uid);
-      tokenText = '--token ' + x.apiKey;
+      const tokenText = '--token ' + x.apiKey;
+      updateInstructions(tokenText);
     }
     else {
-      tokenText = '';
+      updateInstructions('');
     }
   });
+
+  onDestroy(unsubscribe);
+
+  function updateInstructions(tokenText) {
+    instruction = `
+## How to Use CodeAuditor
+Scan any website for broken links, [HTML Issues](https://htmlhint.com), [Google Lighthouse Audit](https://developers.google.com/web/tools/lighthouse) and [Artillery Load Test](https://artillery.io/) by running the following command:
+\`\`\` bash
+$ docker container run --cap-add=SYS_ADMIN sswconsulting/codeauditor ${tokenText} --url <URL>
+\`\`\`
+`;
+
+    instructionSteps = `
+## Instructions to scan a URL 
+### On Windows 
+\`\`\` bash
+1. Download Docker for Windows at https://docs.docker.com/docker-for-windows/install/
+2. Follow the installation steps and run Docker
+3. On CodeAuditor, copy the following command: docker run sswconsulting/codeauditor ${tokenText} --url <URL>
+4. Open Windows Powershell and paste the above command, replace <URL> with your designated url 
+  (make sure to include the full URL with 'https')
+5. Once scan is complete, a result script will display which gives you a link to your scan result page
+\`\`\`
+
+### On Mac 
+\`\`\` bash
+1. Download Docker for Mac at https://docs.docker.com/docker-for-mac/install/
+2. Follow the installation steps and run Docker
+3. On CodeAuditor, copy the following command: docker run sswconsulting/codeauditor ${tokenText} --url <URL>
+4. Open the Terminal and paste the above command, replace <URL> with your designated url 
+  (make sure to include the full URL with 'https')
+5. Once scan is complete, a result script will display which gives you a link to your scan result page
+\`\`\``;
+  };
 
   const systemRequirements = `
   ## System requirements
@@ -26,36 +55,6 @@
   \`\`\` bash
   - Have Docker Desktop running in the background 
   - Have at least 1GB of storage to download the Docker image
-  \`\`\``;
-
-  const instruction = `
-  ## How to Use CodeAuditor
-  Scan any website for broken links, [HTML Issues](https://htmlhint.com), [Google Lighthouse Audit](https://developers.google.com/web/tools/lighthouse) and [Artillery Load Test](https://artillery.io/) by running the following command:
-  \`\`\` bash
-  $ docker container run --cap-add=SYS_ADMIN sswconsulting/codeauditor ${tokenText} --url <URL>
-  \`\`\`
-  `;
-
-  const instructionSteps = `
-  ## Instructions to scan an URL 
-  ### On Windows 
-  \`\`\` bash
-  1. Download Docker for Windows at https://docs.docker.com/docker-for-windows/install/
-  2. Follow the installation steps and run Docker
-  3. On CodeAuditor, copy the following command: docker run sswconsulting/codeauditor ${tokenText} --url <URL>
-  4. Open Windows Powershell and paste the above command, replace <URL> with your designated url 
-    (make sure to include the full URL with 'https')
-  5. Once scan is complete, a result script will display which gives you a link to your scan result page
-  \`\`\`
-
-  ### On Mac 
-  \`\`\` bash
-  1. Download Docker for Mac at https://docs.docker.com/docker-for-mac/install/
-  2. Follow the installation steps and run Docker
-  3. On CodeAuditor, copy the following command: docker run sswconsulting/codeauditor ${tokenText} --url <URL>
-  4. Open the Terminal and paste the above command, replace <URL> with your designated url 
-    (make sure to include the full URL with 'https')
-  5. Once scan is complete, a result script will display which gives you a link to your scan result page
   \`\`\``;
 
   const addingCustomRule = `

--- a/ui/src/containers/HowItWorks.svelte
+++ b/ui/src/containers/HowItWorks.svelte
@@ -8,16 +8,16 @@
   const unsubscribe = userSession$.subscribe((x) => {
     if (x) {
       const tokenText = '--token ' + x.apiKey;
-      updateInstructions(tokenText);
+      updateDockerInstructions(tokenText);
     }
     else {
-      updateInstructions('');
+      updateDockerInstructions('');
     }
   });
 
   onDestroy(unsubscribe);
 
-  function updateInstructions(tokenText) {
+  function updateDockerInstructions(tokenText) {
     instruction = `
 ## How to Use CodeAuditor
 Scan any website for broken links, [HTML Issues](https://htmlhint.com), [Google Lighthouse Audit](https://developers.google.com/web/tools/lighthouse) and [Artillery Load Test](https://artillery.io/) by running the following command:


### PR DESCRIPTION
#647

Updates the How It Works page to update the Docker instructions with the user's token when loading the page fresh.