### PR TITLE
Make history charts clearer

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.4.2",
         "chart.js": "^4.4.0",
+        "chartjs-plugin-datalabels": "^2.2.0",
         "codemirror": "^5.65.15",
         "date-fns": "^2.30.0",
         "export-to-csv": "^0.2.1",
@@ -2584,6 +2585,14 @@
       },
       "engines": {
         "pnpm": ">=7"
+      }
+    },
+    "node_modules/chartjs-plugin-datalabels": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
+      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
+      "peerDependencies": {
+        "chart.js": ">=3.0.0"
       }
     },
     "node_modules/chokidar": {
@@ -6538,17 +6547,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/morgan": {
@@ -14712,6 +14710,12 @@
         "@kurkle/color": "^0.3.0"
       }
     },
+    "chartjs-plugin-datalabels": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
+      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
+      "requires": {}
+    },
     "chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -17766,14 +17770,6 @@
         }
       }
     },
-    "mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "requires": {
-        "minimist": "^1.2.6"
-      }
-    },
     "morgan": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
@@ -20029,6 +20025,14 @@
           "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "requires": {
             "ms": "^2.1.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+          "requires": {
+            "minimist": "^1.2.6"
           }
         },
         "ms": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.4.2",
         "chart.js": "^4.4.0",
-        "chartjs-plugin-datalabels": "^2.2.0",
         "codemirror": "^5.65.15",
         "date-fns": "^2.30.0",
         "export-to-csv": "^0.2.1",
@@ -2585,14 +2584,6 @@
       },
       "engines": {
         "pnpm": ">=7"
-      }
-    },
-    "node_modules/chartjs-plugin-datalabels": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
-      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
-      "peerDependencies": {
-        "chart.js": ">=3.0.0"
       }
     },
     "node_modules/chokidar": {
@@ -14709,12 +14700,6 @@
       "requires": {
         "@kurkle/color": "^0.3.0"
       }
-    },
-    "chartjs-plugin-datalabels": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
-      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
-      "requires": {}
     },
     "chokidar": {
       "version": "3.5.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.4.2",
     "chart.js": "^4.4.0",
+    "chartjs-plugin-datalabels": "^2.2.0",
     "codemirror": "^5.65.15",
     "date-fns": "^2.30.0",
     "export-to-csv": "^0.2.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.4.2",
     "chart.js": "^4.4.0",
-    "chartjs-plugin-datalabels": "^2.2.0",
     "codemirror": "^5.65.15",
     "date-fns": "^2.30.0",
     "export-to-csv": "^0.2.1",

--- a/ui/src/components/buildlistcardcomponents/BuildList.svelte
+++ b/ui/src/components/buildlistcardcomponents/BuildList.svelte
@@ -104,14 +104,14 @@
 
             <div
               class="xl:w-1/4 lg:w-1/4 h-20 hidden sm:hidden md:hidden lg:block
-              xl:block ml-5">
-              <HistoryChart value={groupUrl[url]} dataType={historyChartType.WarningCode} />
+              xl:block ml-5 mr-5">
+              <HistoryChart value={groupUrl[url]} dataType={historyChartType.ErrorCode} />
             </div>
 
             <div
               class="xl:w-1/4 lg:w-1/4 h-20 hidden sm:hidden md:hidden lg:block
-              xl:block ml-5 mr-5">
-              <HistoryChart value={groupUrl[url]} dataType={historyChartType.ErrorCode} />
+              xl:block ml-5">
+              <HistoryChart value={groupUrl[url]} dataType={historyChartType.WarningCode} />
             </div>
           </div>
         </div>

--- a/ui/src/components/buildlistcardcomponents/BuildList.svelte
+++ b/ui/src/components/buildlistcardcomponents/BuildList.svelte
@@ -97,19 +97,19 @@
             </div>
 
             <div
-              class="xl:w-1/4 lg:w-1/4 h-20 hidden sm:hidden md:hidden lg:block
+              class="xl:w-1/4 lg:w-1/4 h-24 hidden sm:hidden md:hidden lg:block
               xl:block">
               <HistoryChart value={groupUrl[url]} dataType={historyChartType.BadLinks} />
             </div>
 
             <div
-              class="xl:w-1/4 lg:w-1/4 h-20 hidden sm:hidden md:hidden lg:block
+              class="xl:w-1/4 lg:w-1/4 h-24 hidden sm:hidden md:hidden lg:block
               xl:block ml-5 mr-5">
               <HistoryChart value={groupUrl[url]} dataType={historyChartType.ErrorCode} />
             </div>
 
             <div
-              class="xl:w-1/4 lg:w-1/4 h-20 hidden sm:hidden md:hidden lg:block
+              class="xl:w-1/4 lg:w-1/4 h-24 hidden sm:hidden md:hidden lg:block
               xl:block ml-5">
               <HistoryChart value={groupUrl[url]} dataType={historyChartType.WarningCode} />
             </div>

--- a/ui/src/components/buildlistcardcomponents/HistoryChart.svelte
+++ b/ui/src/components/buildlistcardcomponents/HistoryChart.svelte
@@ -12,7 +12,7 @@
   let chartTitle;
   let barColor;
   let datalabels = {
-    color: 'black'
+    color: '#333'
   };
 
   // Categorize and populate charts with data, title and color

--- a/ui/src/components/buildlistcardcomponents/HistoryChart.svelte
+++ b/ui/src/components/buildlistcardcomponents/HistoryChart.svelte
@@ -1,13 +1,19 @@
 <script>
   import { historyChartType } from "../../utils/utils";
-  import Chart from 'chart.js/auto'
+  import Chart from 'chart.js/auto';
+  import ChartDataLabels from 'chartjs-plugin-datalabels';
 
   export let value = [];
   export let dataType;
 
+  Chart.register(ChartDataLabels);
+
   let allDataToDisplay = [];
   let chartTitle;
   let barColor;
+  let datalabels = {
+    color: 'black'
+  };
 
   // Categorize and populate charts with data, title and color
   if (dataType === historyChartType.BadLinks) {
@@ -41,7 +47,12 @@
   if (dataToDisplay.every(x => x === 0 || x === undefined)) {
     dataToDisplay = Array(8).fill(1);
     dataToDisplayLabel = Array(8).fill(0);
-    barColor = "#eeeeee"
+    barColor = "#eeeeee";
+    datalabels = {
+      labels: {
+        title: null
+      }
+    };
   }
 
   // Calculate to get max bar height for certain group
@@ -54,13 +65,19 @@
         data: dataToDisplay,
         tension: 0.32,
         borderWidth: 0.1,
+        datalabels
       },
       {
         backgroundColor: "#eeeeee",
         data: Array(8).fill(Math.max(...dataToDisplay)),
         tension: 0.32,
         borderWidth: 0.1,
-        grouped: false
+        grouped: false,
+        datalabels: {
+          labels: {
+            title: null
+          }
+        }
       }
     ],
   }
@@ -78,12 +95,28 @@
 			},
       tooltip: {
         filter: function (tooltipItem) {
-          return tooltipItem.datasetIndex === 0;
+          return tooltipItem.datasetIndex === 0 && tooltipItem.label !== '0';
         },
         callbacks: {
           label: function(context) {
             return null;
           }
+        }
+      },
+      datalabels: {
+        clip: false,
+        font: {
+          size: 8,
+        },
+        formatter: function(value, context) {
+          if (value === 0) {
+            return null;
+          }
+
+          return Intl.NumberFormat('en-US', {
+            notation: "compact",
+            maximumFractionDigits: 0
+          }).format(value);
         }
       }
     },

--- a/ui/src/components/buildlistcardcomponents/HistoryChart.svelte
+++ b/ui/src/components/buildlistcardcomponents/HistoryChart.svelte
@@ -25,7 +25,7 @@
   }
 
   // Show top 8 most recent scan in chart
-  let dataToDisplay = allDataToDisplay.slice(0, 8);
+  let dataToDisplay = allDataToDisplay.slice(0, 8).map((data) => data || 0);
 
   // If a group has less than 8 scans, add the remaining props to populate the chart
   for (let i = 0; i < 8; i++) {
@@ -48,14 +48,10 @@
   let maxBarHeight = dataToDisplay.length > 0 ? dataToDisplay.reduce((a, b) => Math.max(a, b)) : 0;
   let data = {
     labels: dataToDisplayLabel.map((value) => {
-      if (value) {
-        return Intl.NumberFormat('en-US', {
-          notation: "compact",
-          maximumFractionDigits: 0
-        }).format(value);
-      } else {
-        return '0';
-      }
+      return Intl.NumberFormat('en-US', {
+        notation: "compact",
+        maximumFractionDigits: 0
+      }).format(value);
     }),
     datasets: [
       {

--- a/ui/src/components/buildlistcardcomponents/HistoryChart.svelte
+++ b/ui/src/components/buildlistcardcomponents/HistoryChart.svelte
@@ -106,7 +106,7 @@
       datalabels: {
         clip: false,
         font: {
-          size: 8,
+          size: 10,
         },
         formatter: function(value, context) {
           if (value === 0) {

--- a/ui/src/components/buildlistcardcomponents/HistoryChart.svelte
+++ b/ui/src/components/buildlistcardcomponents/HistoryChart.svelte
@@ -1,19 +1,13 @@
 <script>
   import { historyChartType } from "../../utils/utils";
   import Chart from 'chart.js/auto';
-  import ChartDataLabels from 'chartjs-plugin-datalabels';
 
   export let value = [];
   export let dataType;
 
-  Chart.register(ChartDataLabels);
-
   let allDataToDisplay = [];
   let chartTitle;
   let barColor;
-  let datalabels = {
-    color: '#333'
-  };
 
   // Categorize and populate charts with data, title and color
   if (dataType === historyChartType.BadLinks) {
@@ -48,36 +42,26 @@
     dataToDisplay = Array(8).fill(1);
     dataToDisplayLabel = Array(8).fill(0);
     barColor = "#eeeeee";
-    datalabels = {
-      labels: {
-        title: null
-      }
-    };
   }
 
   // Calculate to get max bar height for certain group
   let maxBarHeight = dataToDisplay.length > 0 ? dataToDisplay.reduce((a, b) => Math.max(a, b)) : 0;
   let data = {
-    labels: dataToDisplayLabel,
+    labels: dataToDisplayLabel.map((value) => {
+      return Intl.NumberFormat('en-US', {
+        notation: "compact",
+        maximumFractionDigits: 0
+      }).format(value);
+    }),
     datasets: [
       {
         backgroundColor: barColor,
         data: dataToDisplay,
-        tension: 0.32,
-        borderWidth: 0.1,
-        datalabels
       },
       {
         backgroundColor: "#eeeeee",
         data: Array(8).fill(Math.max(...dataToDisplay)),
-        tension: 0.32,
-        borderWidth: 0.1,
         grouped: false,
-        datalabels: {
-          labels: {
-            title: null
-          }
-        }
       }
     ],
   }
@@ -94,42 +78,24 @@
 				display: false
 			},
       tooltip: {
-        filter: function (tooltipItem) {
-          return tooltipItem.datasetIndex === 0 && tooltipItem.label !== '0';
-        },
-        callbacks: {
-          label: function(context) {
-            return null;
-          }
-        }
+        enabled: false,
       },
-      datalabels: {
-        clip: false,
-        font: {
-          size: 10,
-        },
-        formatter: function(value, context) {
-          if (value === 0) {
-            return null;
-          }
-
-          return Intl.NumberFormat('en-US', {
-            notation: "compact",
-            maximumFractionDigits: 0
-          }).format(value);
-        }
-      }
     },
     scales: {
-			y: {
+      y: {
         display: false,
         max: maxBarHeight,
       },
-			 x: {
-				 display: false,
-         reverse: true
-			 }
-    }
+      x: {
+        display: true,
+        reverse: true,
+        ticks: {
+          font: {
+            size: 10,
+          },
+        },
+      },
+    },
   }
 	
 	$: config = {

--- a/ui/src/components/buildlistcardcomponents/HistoryChart.svelte
+++ b/ui/src/components/buildlistcardcomponents/HistoryChart.svelte
@@ -48,10 +48,14 @@
   let maxBarHeight = dataToDisplay.length > 0 ? dataToDisplay.reduce((a, b) => Math.max(a, b)) : 0;
   let data = {
     labels: dataToDisplayLabel.map((value) => {
-      return Intl.NumberFormat('en-US', {
-        notation: "compact",
-        maximumFractionDigits: 0
-      }).format(value);
+      if (value) {
+        return Intl.NumberFormat('en-US', {
+          notation: "compact",
+          maximumFractionDigits: 0
+        }).format(value);
+      } else {
+        return '0';
+      }
     }),
     datasets: [
       {


### PR DESCRIPTION
#649 

Adds numbers to the bar charts and rearranges so errors appear before warning.

<img width="1099" alt="Screenshot 2023-09-19 at 11 10 24 am" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/2a058bd8-cc35-4346-ad3d-6165212f0e03">

**Figure: Rearranged charts with number count under bars**