### PR TITLE
Disable href-abs-or-rel option

### DIFF
--- a/docker/api.js
+++ b/docker/api.js
@@ -146,7 +146,8 @@ exports.htmlHintConfig = {
   "inline-style-disabled": true,
   "inline-script-disabled": true,
   "id-class-ad-disabled": true,
-  "href-abs-or-rel": true,
+  // Disabled on 20/09/2023
+  // "href-abs-or-rel": true,
   "attr-unsafe-chars": true,
   "head-script-disabled": true,
   "anchor-names-must-be-valid": true,

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -483,12 +483,13 @@ export const htmlHintRules = [
     ruleLink: "https://htmlhint.com/docs/user-guide/rules/alt-require",
     type: RuleType.Warning
   },
-  {
-    rule: "href-abs-or-rel",
-    displayName: "Links - Href attribute must be either absolute or relative",
-    ruleLink: "https://htmlhint.com/docs/user-guide/rules/href-abs-or-rel",
-    type: RuleType.Warning
-  },
+  // Disabled on 20/09/2023
+  // {
+  //   rule: "href-abs-or-rel",
+  //   displayName: "Links - Href attribute must be either absolute or relative",
+  //   ruleLink: "https://htmlhint.com/docs/user-guide/rules/href-abs-or-rel",
+  //   type: RuleType.Warning
+  // },
   {
     rule: "src-not-empty",
     displayName: "Content - The image src attribute must have a value",


### PR DESCRIPTION
#631

Disables the href-abs-or-rel HTMLHint option as it currently doesn't work correctly and the available options don't make much sense with our current sites.