### PR TITLE
UI improvements on Scan Results page

### DIFF
--- a/ui/src/components/artillerycomponents/ArtilleryDetailsCard.svelte
+++ b/ui/src/components/artillerycomponents/ArtilleryDetailsCard.svelte
@@ -25,7 +25,7 @@
 
 <div class="overflow-hidden shadow-lg my-5">
   {#if val.finalEval == 'FAIL'}
-    <div class="bg-red-500 h-2" />
+    <div class="bgred h-2" />
   {:else if val.finalEval == 'PASS'}
     <div class="bg-green-500 h-2" />
   {:else}
@@ -37,19 +37,19 @@
       <div></div>
       <div class="grid auto-rows-auto col-span-6 md:col-span-4">
         <div class="md:row-span-1 text-sm my-2">
-          <h2><span class="font-bold font-sans text-gray-600">LINKS</span></h2>
+          <h2><span class="font-bold font-sans textgrey">LINKS</span></h2>
           <LinkSummary value={val}/>
         </div>
   
         <div class="md:row-span-1 text-sm my-2">
-          <h2><span class="font-bold font-sans text-gray-600">CODE</span></h2>
+          <h2><span class="font-bold font-sans textgrey">CODE</span></h2>
           <CodeSummary value={val} />
         </div>
   
         {#if val.performanceScore}
           <div class="md:row-span-1 text-sm my-2">
             <h2>
-              <span class="font-bold font-sans text-gray-600">LIGHTHOUSE</span>
+              <span class="font-bold font-sans textgrey">LIGHTHOUSE</span>
             </h2>
             <LighthouseSummary value={val} />
           </div>
@@ -57,7 +57,7 @@
   
         <div class="md:row-span-1 text-sm my-2">
           <h2>
-            <span class="font-bold font-sans text-gray-600">LOAD TEST</span>
+            <span class="font-bold font-sans textgrey">LOAD TEST</span>
           </h2>
           <ArtillerySummary value={val} />
         </div>

--- a/ui/src/components/buildlistcardcomponents/UrlSummaryCard.svelte
+++ b/ui/src/components/buildlistcardcomponents/UrlSummaryCard.svelte
@@ -12,7 +12,7 @@
 </script>
 
 <div on:click={() => navigateTo(`/build/${value[0].runId}`)} on:keypress>
-  <p title={url} class="font-sans font-bold text-gray-800 underline">{url}</p>
+  <p title={url} class="font-sans font-bold textdark underline">{url}</p>
   <div class="font-sans text-sm py-4">
     Last scanned
     {formatDistanceToNow(new Date(value[0].buildDate), { addSuffix: true })}

--- a/ui/src/components/detailcardcomponents/BuildDetailsCard.svelte
+++ b/ui/src/components/detailcardcomponents/BuildDetailsCard.svelte
@@ -26,7 +26,7 @@
 
 <div class="overflow-hidden shadow-lg my-5">
   {#if val.finalEval === 'FAIL'}
-    <div class="bg-red-500 h-2" />
+    <div class="bgred h-2" />
   {:else if val.finalEval === 'PASS'}
     <div class="bg-green-500 h-2" />
   {:else}
@@ -39,19 +39,19 @@
       <div class="grid auto-rows-auto col-span-6 md:col-span-4">
         <div
           class="md:row-span-1 text-sm my-2">
-          <h2><span class="font-bold font-sans text-gray-600">LINKS</span></h2>
+          <h2><span class="font-bold font-sans textgrey">LINKS</span></h2>
           <LinkSummary value={val} />
         </div>
   
         <div class="md:row-span-1 text-sm my-2">
-          <h2><span class="font-bold font-sans text-gray-600">CODE</span></h2>
+          <h2><span class="font-bold font-sans textgrey">CODE</span></h2>
           <CodeSummary value={val} />
         </div>
   
         {#if val.performanceScore}
           <div class="md:row-span-1 text-sm my-2">
             <h2>
-              <span class="font-bold font-sans text-gray-600">LIGHTHOUSE</span>
+              <span class="font-bold font-sans textgrey">LIGHTHOUSE</span>
             </h2>
             <LighthouseSummary value={val} />
           </div>
@@ -59,7 +59,7 @@
   
         <div class="md:row-span-1 text-sm my-2">
           <h2>
-            <span class="font-bold font-sans text-gray-600">LOAD TEST</span>
+            <span class="font-bold font-sans textgrey">LOAD TEST</span>
           </h2>
           <ArtillerySummary value={val} />
         </div>

--- a/ui/src/components/detailcardcomponents/DetailListCard.svelte
+++ b/ui/src/components/detailcardcomponents/DetailListCard.svelte
@@ -43,7 +43,7 @@
 {#each value as val}
   <div class="container overflow-hidden shadow-lg my-2">
     {#if val.finalEval === 'FAIL'}
-      <div class="bg-red-500 h-2" />
+      <div class="bgred h-2" />
     {:else if val.finalEval === 'PASS'}
       <div class="bg-green-500 h-2" />
     {:else}
@@ -56,7 +56,7 @@
         on:click={() => navigateTo(`/build/${val.runId}`)}
         on:keydown={undefined}>
         <div class="row-span-1 lg:row-span-4 col-span-4">
-          <span class="font-sans text-base font-bold text-gray-800 underline text-lg">
+          <span class="font-sans text-base font-bold textdark underline text-lg">
             {format(new Date(val.buildDate), 'dd MMM yyyy')}
           </span>
           <br />
@@ -82,7 +82,7 @@
         <div
           class="row-span-1 col-span-4 text-sm my-2">
           <h2>
-            <span class="font-bold font-sans text-gray-600">LINKS</span>
+            <span class="font-bold font-sans textgrey">LINKS</span>
           </h2>
           <LinkSummary value={val}/>
         </div>
@@ -90,7 +90,7 @@
         <div
           class="row-span-1 col-span-4 text-sm my-2">
           <h2>
-            <span class="font-bold font-sans text-gray-600">CODE</span>
+            <span class="font-bold font-sans textgrey">CODE</span>
           </h2>
           <CodeSummary value={val} />
         </div>
@@ -98,7 +98,7 @@
         <div
           class="row-span-1 col-span-4 text-sm my-2">
           <h2>
-            <span class="font-bold font-sans text-gray-600">LOAD TEST</span>
+            <span class="font-bold font-sans textgrey">LOAD TEST</span>
           </h2>
           <ArtillerySummary value={val} />
         </div>
@@ -107,7 +107,7 @@
           <div
             class="row-span-1 col-span-4 text-sm my-2">
             <h2>
-              <span class="font-bold font-sans text-gray-600">LIGHTHOUSE</span>
+              <span class="font-bold font-sans textgrey">LIGHTHOUSE</span>
             </h2>
             <LighthouseSummary value={val} />
           </div>

--- a/ui/src/components/htmlhintcomponents/HTMLHintDetailsCard.svelte
+++ b/ui/src/components/htmlhintcomponents/HTMLHintDetailsCard.svelte
@@ -32,7 +32,7 @@
 
 <div class="overflow-hidden shadow-lg my-5">
   {#if val.finalEval == 'FAIL'}
-    <div class="bg-red-500 h-2" />
+    <div class="bgred h-2" />
   {:else if val.finalEval == 'PASS'}
     <div class="bg-green-500 h-2" />
   {:else}
@@ -44,19 +44,19 @@
       <div></div>
       <div class="grid auto-rows-auto col-span-6 md:col-span-4">
         <div class="md:row-span-1 text-sm my-2">
-          <h2><span class="font-bold font-sans text-gray-600">LINKS</span></h2>
+          <h2><span class="font-bold font-sans textgrey">LINKS</span></h2>
           <LinkSummary value={val} />
         </div>
   
         <div class="md:row-span-1 text-sm my-2">
-          <h2><span class="font-bold font-sans text-gray-600">CODE</span></h2>
+          <h2><span class="font-bold font-sans textgrey">CODE</span></h2>
           <CodeSummary value={val} />
         </div>
   
         {#if val.performanceScore}
           <div class="md:row-span-1 text-sm my-2">
             <h2>
-              <span class="font-bold font-sans text-gray-600">LIGHTHOUSE</span>
+              <span class="font-bold font-sans textgrey">LIGHTHOUSE</span>
             </h2>
             <LighthouseSummary value={val} />
           </div>
@@ -64,7 +64,7 @@
   
         <div class="md:row-span-1 text-sm my-2">
           <h2>
-            <span class="font-bold font-sans text-gray-600">LOAD TEST</span>
+            <span class="font-bold font-sans textgrey">LOAD TEST</span>
           </h2>
           <ArtillerySummary value={val} />
         </div>

--- a/ui/src/components/htmlhintcomponents/HtmlErrorsTable.svelte
+++ b/ui/src/components/htmlhintcomponents/HtmlErrorsTable.svelte
@@ -167,7 +167,7 @@
       <button
         on:click={download}
         title="Download CSV"
-        class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-1 px-1
+        class="bg-gray-300 hover:bg-gray-400 textdark font-bold py-1 px-1
         rounded-lg inline-flex items-center">
         <Icon cssClass="">
           <path

--- a/ui/src/components/lighthousecomponents/LighthouseDetailsCard.svelte
+++ b/ui/src/components/lighthousecomponents/LighthouseDetailsCard.svelte
@@ -25,7 +25,7 @@
 
 <div class="overflow-hidden shadow-lg my-5">
   {#if val.finalEval == 'FAIL'}
-    <div class="bg-red-500 h-2" />
+    <div class="bgred h-2" />
   {:else if val.finalEval == 'PASS'}
     <div class="bg-green-500 h-2" />
   {:else}
@@ -37,19 +37,19 @@
       <div></div>
       <div class="grid auto-rows-auto col-span-6 md:col-span-4">
         <div class="md:row-span-1 text-sm my-2">
-          <h2><span class="font-bold font-sans text-gray-600">LINKS</span></h2>
+          <h2><span class="font-bold font-sans textgrey">LINKS</span></h2>
           <LinkSummary value={val} />
         </div>
   
         <div class="md:row-span-1 text-sm my-2">
-          <h2><span class="font-bold font-sans text-gray-600">CODE</span></h2>
+          <h2><span class="font-bold font-sans textgrey">CODE</span></h2>
           <CodeSummary value={val} />
         </div>
   
         {#if val.performanceScore}
           <div class="md:row-span-1 text-sm my-2">
             <h2>
-              <span class="font-bold font-sans text-gray-600">LIGHTHOUSE</span>
+              <span class="font-bold font-sans textgrey">LIGHTHOUSE</span>
             </h2>
             <LighthouseSummary value={val} />
           </div>
@@ -57,7 +57,7 @@
   
         <div class="md:row-span-1 text-sm my-2">
           <h2>
-            <span class="font-bold font-sans text-gray-600">LOAD TEST</span>
+            <span class="font-bold font-sans textgrey">LOAD TEST</span>
           </h2>
           <ArtillerySummary value={val} />
         </div>

--- a/ui/src/components/linkauditorcomponents/DetailsByDest.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsByDest.svelte
@@ -2,9 +2,11 @@
   import { fade } from "svelte/transition";
   import Icon from "../misccomponents/Icon.svelte";
   import { groupBy, props } from "ramda";
-  import { ignoredUrls$ } from "../../stores.js";
-  import { isInIgnored } from "../../utils/utils.js";
+  import { ignoredUrls$, deleteIgnoreUrl, userSession$ } from "../../stores.js";
+  import { isInIgnored, getMatchingIgnoredRules } from "../../utils/utils.js";
   import { createEventDispatcher } from "svelte";
+  import LoadingCircle from "../misccomponents/LoadingCircle.svelte";
+  import Toastr from "../misccomponents/Toastr.svelte";
   const dispatch = createEventDispatcher();
 
   export let builds = [];
@@ -12,10 +14,19 @@
   const ignore = url => dispatch("ignore", url);
   let destinations;
   let destinationsKeys = [];
+  let ignoredChecks = [];
+  let loadingChecks = [];
+  let deleteUrl = '';
+  let addedFailedToast = false;
 
   $: if (builds.length > 0) {
     destinations = groupBy(props(["dst"]))(builds);
     destinationsKeys = Object.keys(destinations);
+
+    ignoredChecks = builds.reduce((acc, val) => {
+      acc[val.dst] = isInIgnored(val.dst, ignoredPatterns);
+      return acc;
+    }, {});
   }
 
   let ignoredPatterns = [];
@@ -32,6 +43,29 @@
       return `Unfixed for ${daysNum} days`;
     } else {
       return '';
+    }
+  };
+
+  const deleteIgnore = async (url) => {
+    deleteUrl = url;
+    loadingChecks[url] = true;
+    const rules = getMatchingIgnoredRules(url, ignoredPatterns);
+    try {
+      for await (const rule of rules) {
+        await deleteIgnoreUrl(rule, $userSession$);
+      }
+    } catch (error) {
+      addedFailedToast = true;
+    } finally {
+      loadingChecks[url] = false;
+    }
+  };
+
+  const toggleIgnore = async (url) => {
+    if (ignoredChecks[url]) {
+      await deleteIgnore(url);
+    } else {
+      ignore(url);
     }
   };
 </script>
@@ -54,34 +88,22 @@
     <a class="mr-2 inline-block align-baseline link" target="_blank" href={url}>
       {url}
     </a>
-    {#if isInIgnored(url, ignoredPatterns)}
-      <span
-        title="This is URL is in the ignored lists. Go to Settings to remove it">
-        <Icon cssClass="text-red-600 inline-block">
-          <path
-            d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636
-            5.636m12.728 12.728L5.636 5.636" />
-        </Icon>
-      </span>
-    {:else}
-      <button
-        title="Ignore this broken link in the next scan"
-        on:click={() => ignore(url)}
-        class="hover:bg-gray-400 rounded inline-flex align-middle mr-3">
-        <Icon>
-          <path
-            d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636
-            5.636m12.728 12.728L5.636 5.636" />
-        </Icon>
-      </button>
-    {/if}
   </div>
   {#if !hiddenRows[url]}
-    {#if destinations[url][0].daysUnfixed > -1}
     <div class="font-bold textgrey ml-2">
-      <i class="fas fa-exclamation-triangle"></i>
-      {formatDaysUnfixed(destinations[url][0].daysUnfixed)}
+      <i class="fas fa-ban"></i>
+      Ignore: 
+      {#if loadingChecks[url]}
+        <LoadingCircle />
+      {:else}
+        <input type="checkbox" on:click={() => toggleIgnore(url)} bind:checked={ignoredChecks[url]} />
+      {/if}
     </div>
+    {#if destinations[url][0].daysUnfixed > -1}
+      <div class="font-bold text-yellow-600 ml-2">
+        <i class="fas fa-exclamation-triangle"></i>
+        {formatDaysUnfixed(destinations[url][0].daysUnfixed)}
+      </div>
     {/if}
     <table
       class="table-fixed w-full md:table-auto mb-8"
@@ -113,3 +135,11 @@
     </table>
   {/if}
 {/each}
+
+<Toastr bind:show={addedFailedToast} mode="error">
+  <p class="font-bold">Failure</p>
+  <p class="text-sm">
+    Failed to remove
+    <span class="font-bold">{deleteUrl}</span>
+  </p>
+</Toastr>

--- a/ui/src/components/linkauditorcomponents/DetailsByReason.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsByReason.svelte
@@ -1,10 +1,12 @@
 <script>
   import { groupBy, props } from "ramda";
-  import { isInIgnored } from "../../utils/utils.js";
-  import { ignoredUrls$ } from "../../stores.js";
+  import { isInIgnored, getMatchingIgnoredRules } from "../../utils/utils.js";
+  import { ignoredUrls$, deleteIgnoreUrl, userSession$ } from "../../stores.js";
   import { createEventDispatcher } from "svelte";
   import { fade } from "svelte/transition";
   import Icon from "../misccomponents/Icon.svelte";
+  import LoadingCircle from "../misccomponents/LoadingCircle.svelte";
+  import Toastr from "../misccomponents/Toastr.svelte";
   export let builds = [];
   const dispatch = createEventDispatcher();
   const ignore = url => dispatch("ignore", url);
@@ -12,10 +14,19 @@
   let reasons;
   let reasonsKeys = [];
   let hiddenRows = {};
+  let ignoredChecks = [];
+  let loadingChecks = [];
+  let deleteUrl = '';
+  let addedFailedToast = false;
 
   $: if (builds.length > 0) {
     reasons = groupBy(props(["statusmsg"]))(builds);
     reasonsKeys = Object.keys(reasons);
+
+    ignoredChecks = builds.reduce((acc, val) => {
+      acc[val.dst] = isInIgnored(val.dst, ignoredPatterns);
+      return acc;
+    }, {});
   }
   let ignoredPatterns = [];
   ignoredUrls$.subscribe(x => (ignoredPatterns = x));
@@ -30,6 +41,29 @@
       return daysNum.toString();
     } else {
       return '-';
+    }
+  };
+
+  const deleteIgnore = async (url) => {
+    deleteUrl = url;
+    loadingChecks[url] = true;
+    const rules = getMatchingIgnoredRules(url, ignoredPatterns);
+    try {
+      for await (const rule of rules) {
+        await deleteIgnoreUrl(rule, $userSession$);
+      }
+    } catch (error) {
+      addedFailedToast = true;
+    } finally {
+      loadingChecks[url] = false;
+    }
+  };
+
+  const toggleIgnore = async (url) => {
+    if (ignoredChecks[url]) {
+      await deleteIgnore(url);
+    } else {
+      ignore(url);
     }
   };
 </script>
@@ -63,6 +97,7 @@
           <th class="w-2/12 px-4 py-2">Anchor Text</th>
           <th class="w-1/12 px-4 py-2 text-right">Status</th>
           <th class="w-1/12 px-4 py-2 text-right">Days Unfixed</th>
+          <th class="hidden md:table-cell w-1/12 px-4 py-2">Ignore</th>
         </tr>
       </thead>
       <tbody>
@@ -83,30 +118,6 @@
                 href={val.dst}>
                 {val.dst.length < 70 ? val.dst : val.dst.substring(0, 70) + '...'}
               </a>
-              {#if isInIgnored(val.dst, ignoredPatterns)}
-                <span
-                  class="inline-block align-middle"
-                  title="This is URL is in the ignored lists. Go to Settings to
-                  remove it">
-                  <Icon cssClass="textred">
-                    <path
-                      d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0
-                      015.636 5.636m12.728 12.728L5.636 5.636" />
-                  </Icon>
-                </span>
-              {:else}
-                <button
-                  title="Ignore this broken link in the next scan"
-                  on:click={() => ignore(val.dst)}
-                  class="bg-gray-200 hover:bg-gray-400 rounded inline-flex
-                  align-middle mr-3">
-                  <Icon>
-                    <path
-                      d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0
-                      015.636 5.636m12.728 12.728L5.636 5.636" />
-                  </Icon>
-                </button>
-              {/if}
             </td>
             <td class="w-2/12 border px-4 py-2 break-all">{val.link || ''}</td>
             <td class="w-1/12 border px-4 py-2 text-right">
@@ -115,9 +126,24 @@
             <td class="w-1/12 border px-4 py-2 text-right">
               {formatDaysUnfixed(val.daysUnfixed)}
             </td>
+            <td class="hidden md:table-cell w-1/12 border px-4 py-2 text-center">
+              {#if loadingChecks[val.dst]}
+                <LoadingCircle />
+              {:else}
+                <input type="checkbox" on:click={() => toggleIgnore(val.dst)} bind:checked={ignoredChecks[val.dst]} />
+              {/if}
+            </td>
           </tr>
         {/each}
       </tbody>
     </table>
   {/if}
 {/each}
+
+<Toastr bind:show={addedFailedToast} mode="error">
+  <p class="font-bold">Failure</p>
+  <p class="text-sm">
+    Failed to remove
+    <span class="font-bold">{deleteUrl}</span>
+  </p>
+</Toastr>

--- a/ui/src/components/linkauditorcomponents/DetailsByReason.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsByReason.svelte
@@ -93,7 +93,7 @@
       <thead>
         <tr>
           <th class="w-4/12 px-2 py-2">Source ({reasons[reason].length})</th>
-          <th class="w-4/12 px-2 py-2">Destination</th>
+          <th class="w-3/12 px-2 py-2">Destination</th>
           <th class="w-2/12 px-2 py-2">Anchor Text</th>
           <th class="w-1/12 px-2 py-2 text-right">Status</th>
           <th class="w-1/12 px-2 py-2 text-right">Days Unfixed</th>
@@ -111,7 +111,7 @@
                 {val.src}
               </a>
             </td>
-            <td class="w-4/12 border px-2 py-2 break-all">
+            <td class="w-3/12 border px-2 py-2 break-all">
               <a
                 class="inline-block align-baseline"
                 target="_blank"

--- a/ui/src/components/linkauditorcomponents/DetailsByReason.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsByReason.svelte
@@ -92,18 +92,18 @@
       out:fade={{ y: -100, duration: 200 }}>
       <thead>
         <tr>
-          <th class="w-4/12 px-4 py-2">Source ({reasons[reason].length})</th>
-          <th class="w-4/12 px-4 py-2">Destination</th>
-          <th class="w-2/12 px-4 py-2">Anchor Text</th>
-          <th class="w-1/12 px-4 py-2 text-right">Status</th>
-          <th class="w-1/12 px-4 py-2 text-right">Days Unfixed</th>
-          <th class="hidden md:table-cell w-1/12 px-4 py-2">Ignore</th>
+          <th class="w-4/12 px-2 py-2">Source ({reasons[reason].length})</th>
+          <th class="w-4/12 px-2 py-2">Destination</th>
+          <th class="w-2/12 px-2 py-2">Anchor Text</th>
+          <th class="w-1/12 px-2 py-2 text-right">Status</th>
+          <th class="w-1/12 px-2 py-2 text-right">Days Unfixed</th>
+          <th class="hidden md:table-cell w-1/12 px-2 py-2">Ignore</th>
         </tr>
       </thead>
       <tbody>
         {#each reasons[reason] as val}
           <tr>
-            <td class="w-4/12 border px-4 py-2 break-all">
+            <td class="w-4/12 border px-2 py-2 break-all">
               <a
                 class="inline-block align-baseline link"
                 target="_blank"
@@ -111,7 +111,7 @@
                 {val.src}
               </a>
             </td>
-            <td class="w-4/12 border px-4 py-2 break-all">
+            <td class="w-4/12 border px-2 py-2 break-all">
               <a
                 class="inline-block align-baseline"
                 target="_blank"
@@ -119,14 +119,14 @@
                 {val.dst.length < 70 ? val.dst : val.dst.substring(0, 70) + '...'}
               </a>
             </td>
-            <td class="w-2/12 border px-4 py-2 break-all">{val.link || ''}</td>
-            <td class="w-1/12 border px-4 py-2 text-right">
+            <td class="w-2/12 border px-2 py-2 break-all">{val.link || ''}</td>
+            <td class="w-1/12 border px-2 py-2 text-right">
               {val.statuscode || '0'}
             </td>
-            <td class="w-1/12 border px-4 py-2 text-right">
+            <td class="w-1/12 border px-2 py-2 text-right">
               {formatDaysUnfixed(val.daysUnfixed)}
             </td>
-            <td class="hidden md:table-cell w-1/12 border px-4 py-2 text-center">
+            <td class="hidden md:table-cell w-1/12 border px-2 py-2 text-center">
               {#if loadingChecks[val.dst]}
                 <LoadingCircle />
               {:else}

--- a/ui/src/components/linkauditorcomponents/DetailsBySource.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsBySource.svelte
@@ -92,7 +92,7 @@
       out:fade={{ y: -100, duration: 200 }}>
       <thead>
         <tr>
-          <th class="w-6/12 px-2 py-2">Broken Link ({sources[url].length})</th>
+          <th class="w-5/12 px-2 py-2">Broken Link ({sources[url].length})</th>
           <th class="hidden md:table-cell w-2/12 px-2 py-2">Anchor Text</th>
           <th class="w-1/12 px-2 py-2 text-right">Status</th>
           <th class="hidden md:table-cell w-2/12 px-2 py-2 text-right">Message</th>
@@ -103,7 +103,7 @@
       <tbody>
         {#each sources[url] as val}
           <tr>
-            <td class="w-6/12 border px-2 py-2 break-all">
+            <td class="w-5/12 border px-2 py-2 break-all">
               <a
                 class="inline-block align-baseline link"
                 target="_blank"

--- a/ui/src/components/linkauditorcomponents/DetailsBySource.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsBySource.svelte
@@ -37,7 +37,7 @@
 
 {#each sourcesKeys as url}
   <div class="mb-3">
-    <span class="font-bold mr-2">
+    <span class="font-bold">
       <Icon
         on:click={() => hideShow(url)}
         cssClass="inline-block cursor-pointer">
@@ -49,9 +49,7 @@
       </Icon>
       Broken links on:
     </span>
-    <a class="inline-block align-baseline link" target="_blank" href={url}>
-      {url}
-    </a>
+    <a class="inline-block align-baseline link" target="_blank" href={url}>{url}</a>
   </div>
   {#if !hiddenRows[url]}
     <table

--- a/ui/src/components/linkauditorcomponents/DetailsBySource.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsBySource.svelte
@@ -92,18 +92,18 @@
       out:fade={{ y: -100, duration: 200 }}>
       <thead>
         <tr>
-          <th class="w-6/12 px-4 py-2">Broken Link ({sources[url].length})</th>
-          <th class="hidden md:table-cell w-2/12 px-4 py-2">Anchor Text</th>
-          <th class="w-1/12 px-4 py-2 text-right">Status</th>
-          <th class="hidden md:table-cell w-2/12 px-4 py-2 text-right">Message</th>
-          <th class="hidden md:table-cell w-1/12 px-4 py-2 text-right">Days Unfixed</th>
-          <th class="hidden md:table-cell w-1/12 px-4 py-2">Ignore</th>
+          <th class="w-6/12 px-2 py-2">Broken Link ({sources[url].length})</th>
+          <th class="hidden md:table-cell w-2/12 px-2 py-2">Anchor Text</th>
+          <th class="w-1/12 px-2 py-2 text-right">Status</th>
+          <th class="hidden md:table-cell w-2/12 px-2 py-2 text-right">Message</th>
+          <th class="hidden md:table-cell w-1/12 px-2 py-2 text-right">Days Unfixed</th>
+          <th class="hidden md:table-cell w-1/12 px-2 py-2">Ignore</th>
         </tr>
       </thead>
       <tbody>
         {#each sources[url] as val}
           <tr>
-            <td class="w-6/12 border px-4 py-2 break-all">
+            <td class="w-6/12 border px-2 py-2 break-all">
               <a
                 class="inline-block align-baseline link"
                 target="_blank"
@@ -112,17 +112,17 @@
               </a>
 
             </td>
-            <td class="hidden md:table-cell w-2/12 border px-4 py-2 break-all">{val.link || ''}</td>
-            <td class="w-1/12 border px-4 py-2 text-right">
+            <td class="hidden md:table-cell w-2/12 border px-2 py-2 break-all">{val.link || ''}</td>
+            <td class="w-1/12 border px-2 py-2 text-right">
               {val.statuscode || '0'}
             </td>
-            <td class="hidden md:table-cell w-2/12 border px-4 py-2 text-right">
+            <td class="hidden md:table-cell w-2/12 border px-2 py-2 text-right">
               {val.statusmsg || ''}
             </td>
-            <td class="hidden md:table-cell w-1/12 border px-4 py-2 text-right">
+            <td class="hidden md:table-cell w-1/12 border px-2 py-2 text-right">
               {formatDaysUnfixed(val.daysUnfixed)}
             </td>
-            <td class="hidden md:table-cell w-1/12 border px-4 py-2 text-center">
+            <td class="hidden md:table-cell w-1/12 border px-2 py-2 text-center">
               {#if loadingChecks[val.dst]}
                 <LoadingCircle />
               {:else}

--- a/ui/src/components/linkauditorcomponents/DetailsTable.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsTable.svelte
@@ -106,7 +106,7 @@
       <button
         on:click={download}
         title="Download CSV"
-        class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-1 px-1
+        class="bg-gray-300 hover:bg-gray-400 textdark font-bold py-1 px-1
         rounded-lg inline-flex items-center">
         <Icon cssClass="">
           <path

--- a/ui/src/components/misccomponents/Breadcrumbs.svelte
+++ b/ui/src/components/misccomponents/Breadcrumbs.svelte
@@ -3,7 +3,7 @@
   export let displayMode = "";
 </script>
 
-<p class="hidden md:block text-sm text-gray-800 pb-3 pt-4">
+<p class="hidden md:block text-sm textdark pb-3 pt-4">
   <a
     class="inline-block align-baseline text-blue hover:text-blue-darker"
     href="/">

--- a/ui/src/components/misccomponents/IgnoreLists.svelte
+++ b/ui/src/components/misccomponents/IgnoreLists.svelte
@@ -1,7 +1,7 @@
 <script>
   import format from "date-fns/format";
   import Toastr from "./Toastr.svelte";
-  import LoadingCirle from "./LoadingCircle.svelte";
+  import LoadingCircle from "./LoadingCircle.svelte";
   import Icon from "./Icon.svelte";
   import { userSession$, deleteIgnoreUrl } from "../../stores";
 
@@ -74,7 +74,7 @@
           </td>
           <td class="border px-4 py-2">
             {#if loading && val.urlToIgnore === deleteUrl}
-              <LoadingCirle />
+              <LoadingCircle />
             {:else}
               <a
                 href={'#'}
@@ -94,7 +94,7 @@
   </table>
 {/if}
 
-<Toastr bind:show={addedFailedToast}>
+<Toastr bind:show={addedFailedToast} mode="error">
   <p class="font-bold">Failure</p>
   <p class="text-sm">
     Failed to remove

--- a/ui/src/components/misccomponents/Tabs.svelte
+++ b/ui/src/components/misccomponents/Tabs.svelte
@@ -4,7 +4,7 @@
   export let build = {};
   export let displayMode = "";
 
-  let baseClass = "bg-white inline-block py-2 px-4 text-gray-600 font-semibold";
+  let baseClass = "bg-white inline-block py-2 px-4 textgrey font-semibold";
   let active = " textgrey border-l border-t border-r rounded-t";
   $: codeSummary = getCodeSummary(build.summary);
 

--- a/ui/src/components/misccomponents/UpdateIgnoreUrl.svelte
+++ b/ui/src/components/misccomponents/UpdateIgnoreUrl.svelte
@@ -50,6 +50,11 @@
       throw new Error("Failed to load");
     }
   };
+
+  $: if (show) {
+    ignoreOn = "all";
+    ignoreDuration = 3;
+  }
 </script>
 
 <style>

--- a/ui/src/components/summaryitemcomponents/ArtillerySummary.svelte
+++ b/ui/src/components/summaryitemcomponents/ArtillerySummary.svelte
@@ -24,7 +24,7 @@
     <span 
       class="font-sans font-bold block lg:inline-block"
       class:text-red-600={value.errors > 0}
-      class:text-gray-600={value.errors == 0}
+      class:textgrey={value.errors == 0}
     >
       {numberWithCommas(value.errors)} 
       {#if value.errors === 0}

--- a/ui/src/components/summaryitemcomponents/CardSummary.svelte
+++ b/ui/src/components/summaryitemcomponents/CardSummary.svelte
@@ -53,17 +53,17 @@
       <a
         href={value.url}
         target="_blank"
-        class="underline text-xl font-sans font-bold text-gray-800 hover:text-red-600">{value.url}</a>
+        class="underline text-xl font-sans font-bold textdark hover:text-red-600">{value.url}</a>
     </div>
     <div class="text-center">
-      <span class="text-xl font-sans block lg:inline-block text-gray-600">Last
+      <span class="text-xl font-sans block lg:inline-block textgrey">Last
         scanned: 
         <strong>{format(new Date(value.buildDate), 'dd MMM yyyy')}</strong>
         ({formatDistanceToNow(new Date(value.buildDate), { addSuffix: true })} at {format(new Date(value.buildDate), 'hh:mmaaa')})
       </span>
     </div>
     <div class="text-center">
-      <span class="text-xl font-sans block lg:inline-block text-gray-600">
+      <span class="text-xl font-sans block lg:inline-block textgrey">
         Duration: {printTimeDiff(+value.scanDuration)}
       </span>
     </div>

--- a/ui/src/components/summaryitemcomponents/CodeSummary.svelte
+++ b/ui/src/components/summaryitemcomponents/CodeSummary.svelte
@@ -41,7 +41,7 @@
     <span
       class="font-sans font-bold block lg:inline-block"
       class:text-yellow-600={codeSummary.htmlWarnings > 0}
-      class:text-gray-600={codeSummary.htmlWarnings == 0}
+      class:textgrey={codeSummary.htmlWarnings == 0}
       title={(codeSummary.codeIssueList || '') + '\n\n\n' + (codeSummary.htmlIssueList || '')}>
       {numberWithCommas((codeSummary.htmlWarnings || 0) + (codeSummary.codeWarnings || 0))}
       {#if codeSummary.htmlWarnings == 0}
@@ -57,7 +57,7 @@
       <span
         class="font-sans font-bold block lg:inline-block"
         class:text-red-600={codeSummary.htmlErrors > 0}
-        class:text-gray-600={codeSummary.htmlErrors === 0}
+        class:textgrey={codeSummary.htmlErrors === 0}
         title={(codeSummary.codeIssueList || '') + '\n\n\n' + (codeSummary.htmlIssueList || '')}>
         {numberWithCommas((codeSummary.htmlErrors || 0) + (codeSummary.codeErrors || 0))}
         {#if codeSummary.htmlErrors == 0}

--- a/ui/src/components/summaryitemcomponents/LinkSummary.svelte
+++ b/ui/src/components/summaryitemcomponents/LinkSummary.svelte
@@ -20,7 +20,7 @@
     <span
       class="font-sans font-bold block lg:inline-block"
       class:text-red-600={value.totalUnique404 > 0}
-      class:text-gray-600={value.totalUnique404 === 0}>
+      class:textgrey={value.totalUnique404 === 0}>
       {value.totalUnique404}
       {#if value.totalUnique404 === 0}
         <i class="fas fa-check"></i>

--- a/ui/src/containers/ArtilleryReport.svelte
+++ b/ui/src/containers/ArtilleryReport.svelte
@@ -102,7 +102,7 @@
               <button
                 on:click={download}
                 title="Download JSON"
-                class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-1 px-1
+                class="bg-gray-300 hover:bg-gray-400 textdark font-bold py-1 px-1
               rounded-lg inline-flex items-center">
                 <Icon cssClass="">
                   <path

--- a/ui/src/containers/LighthouseReport.svelte
+++ b/ui/src/containers/LighthouseReport.svelte
@@ -108,7 +108,7 @@
         <button
           on:click={download}
           title="Download JSON"
-          class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-1 px-1
+          class="bg-gray-300 hover:bg-gray-400 textdark font-bold py-1 px-1
           rounded-lg inline-flex items-center">
           <Icon cssClass="">
             <path

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -126,6 +126,10 @@ export const getLoadThresholdResult = (value) => ({
 });
 
 export const isInIgnored = (url, list) => {
+  return getMatchingIgnoredRules(url, list).length > 0;
+};
+
+export const getMatchingIgnoredRules = (url, list) => {
   function glob(pattern, input) {
     var re = new RegExp(
       pattern.replace(/([.?+^$[\]\\(){}|\/-])/g, "\\$1").replace(/\*/g, ".*")
@@ -133,22 +137,14 @@ export const isInIgnored = (url, list) => {
     return re.test(input);
   }
   const date = new Date();
-  for (let index = 0; index < list.length; index++) {
-    const item = list[index];
+  return list.filter((item) => {
     const pattern = item.urlToIgnore;
     if (glob(pattern, url)) {
       const effectiveFrom = new Date(item.effectiveFrom);
-      const timelapsed = (date - effectiveFrom) / 86400000;
-      if (
-        (item.ignoreDuration > 0 && timelapsed < item.ignoreDuration) ||
-        item.ignoreDuration === -1
-      ) {
-        console.log("Remaing days", item.ignoreDuration - timelapsed);
-        return true;
-      }
+      const timeElapsed = (date - effectiveFrom) / 86400000;
+      return (item.ignoreDuration > 0 && timeElapsed < item.ignoreDuration) || item.ignoreDuration === -1;
     }
-  }
-  return null;
+  });
 };
 
 export const getHtmlIssuesDescriptions = pipe(


### PR DESCRIPTION
#654

This moves the ignore URL button into a more intuitive checkbox and allows for disabling from within the same UI.

Also implements some colour updates as per the related issue.

<img width="1008" alt="Screenshot 2023-09-20 at 2 29 53 pm" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/ec0b5695-5a6f-47d0-a352-0c8d5b494498">

**Figure: New checkbox column for Ignore**

<img width="1009" alt="Screenshot 2023-09-20 at 2 30 27 pm" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/d9b6d940-8bd8-40d6-86d7-676f70319e77">

**Figure: Tweaked colours to be more consistent with company colours**