### PR TITLE
Fix Scan History toggle inconsistencies

### DIFF
--- a/ui/src/components/buildlistcardcomponents/BuildList.svelte
+++ b/ui/src/components/buildlistcardcomponents/BuildList.svelte
@@ -10,7 +10,6 @@
   export let builds = [];
   export let lastBuild;
 
-  let showTotalBuild = false;
   let groupUrlKey = [];
   let groupUrl;
   groupUrl = groupBy(props(["url"]))(builds);
@@ -23,16 +22,10 @@
 
   let currCard;
   function toggle(n) {
-    currCard = n;
-    showTotalBuild = !showTotalBuild;
-    const x = document.getElementById("detailCard");
-
-    if (x) {
-      if (x.style.display === "none") {
-        x.style.display = "block";
-      } else {
-        x.style.display = "none";
-      }
+    if (currCard === n) {
+      currCard = -1;
+    } else {
+      currCard = n;
     }
   }
 </script>
@@ -83,7 +76,7 @@
                 class="hover:bg-gray-300 border-0 rounded-md px-3 py-1"
                 on:click={() => toggle(i)}
                 on:keydown>
-                {#if showTotalBuild}
+                {#if currCard === i}
                   <i class="fas fa-angle-up"></i>
                 {:else}
                   <i class="fas fa-angle-down"></i>

--- a/ui/src/components/buildlistcardcomponents/BuildList.svelte
+++ b/ui/src/components/buildlistcardcomponents/BuildList.svelte
@@ -20,7 +20,7 @@
     x => new Date(x.buildDate) > addDays(new Date(), -30)
   ).length;
 
-  let currCard;
+  let currCard = -1;
   function toggle(n) {
     if (currCard === n) {
       currCard = -1;


### PR DESCRIPTION
#662

Small fix to simplify the handling of the Scan History toggles so each toggle works independently and can't end up out of sync with the expansion state.

<img width="483" alt="Screenshot 2023-09-21 at 4 52 20 pm" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/caaa2c20-20f3-4699-87df-cad23b1eb1d0">

**Figure: Toggles are now independent of each other**

<img width="477" alt="Screenshot 2023-09-21 at 4 52 57 pm" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/27f8a663-5dec-4e21-8ec3-75604bdb648c">

**Figure: Toggling between multiple Scan Histories no longer leaves the icons in an inconsistent state**