### PR TITLE
Update Modal z-index

### DIFF
--- a/ui/src/components/misccomponents/Modal.svelte
+++ b/ui/src/components/misccomponents/Modal.svelte
@@ -21,6 +21,7 @@
 <style>
   .modal {
     transition: opacity 0.2s ease;
+    z-index: 3000;
   }
   .fullheight {
     height: 90vh;


### PR DESCRIPTION
#672

Small fix to add a z-index to the Modal component so it can't be overlapped by elements underneath.

<img width="1163" alt="Screenshot 2023-09-28 at 5 07 11 pm" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/7e528d42-3a6a-463c-b0f6-8d8862694890">

**Figure: Modal is no longer overlapped by Lighthouse elements underneath**