### PR TITLE
Build List UI - Fix grouping scans by Urls

### DIFF
--- a/ui/src/components/buildlistcardcomponents/BuildList.svelte
+++ b/ui/src/components/buildlistcardcomponents/BuildList.svelte
@@ -12,6 +12,10 @@
 
   let groupUrlKey = [];
   let groupUrl;
+  
+  // Remove 'www.' before grouping the scans by the Urls
+  builds = builds.map(item => ({...item, url: item.url.replace('www.', '')}))
+  
   groupUrl = groupBy(props(["url"]))(builds);
   groupUrlKey = Object.keys(groupUrl);
 


### PR DESCRIPTION
Scans with similar Urls should be merged regardless of having "www".

<img width="830" alt="image" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/67776356/786f6eea-c75d-45ee-9db5-cb589df5caad">
