### PR TITLE
Modified "aka" custom rule to include more spelling mistakes

### DIFF
--- a/docker/api.js
+++ b/docker/api.js
@@ -162,5 +162,5 @@ exports.htmlHintConfig = {
   "figure-must-use-the-right-code": true,
   "detect-absolute-references-url-path-correctly": true,
   "use-unicode-hex-code-for-special-html-characters": true,
-  "aka-must-be-spelt-correctly": true,
+  "common-spelling-mistakes": true
 };

--- a/docker/customHtmlRules.js
+++ b/docker/customHtmlRules.js
@@ -419,9 +419,9 @@ exports.addCustomHtmlRule = () => {
   });
 
   HTMLHint.addRule({
-    id: "aka-must-be-spelt-correctly",
+    id: "common-spelling-mistakes",
     description:
-      "Checks that \"aka\" is spelt correctly.",
+      "Checks common spelling mistakes.",
     init: function (parser, reporter) {
       var self = this;
 
@@ -430,10 +430,16 @@ exports.addCustomHtmlRule = () => {
           "a.k.a",
           "A.K.A",
           "AKA",
+          "e-mail",
+          "EMail",
+          "can not",
+          "web site",
+          "user name",
+          "task bar"
         ];
 
         if (event.tagName) {
-          if (event.tagName !== "meta" && event.tagName !== "link" && event.tagName !== "script" && event.tagName !== "svg") { 
+          if (event.tagName !== "a" && event.tagName !== "meta" && event.tagName !== "link" && event.tagName !== "script" && event.tagName !== "svg") { 
             if (event.lastEvent) {
               let pageContent = event.lastEvent.raw;
               if (pageContent) {
@@ -443,7 +449,7 @@ exports.addCustomHtmlRule = () => {
 
                   if (contentIndex >= 0) {
                     reporter.warn(
-                      "Incorrect spelling of \"aka\": '" + i + "'.",
+                      "Incorrect spellings: '" + i + "'.",
                       event.line,
                       col,
                       self,

--- a/docker/test/common-spelling-mistakes.spec.js
+++ b/docker/test/common-spelling-mistakes.spec.js
@@ -1,7 +1,7 @@
 const expect = require("expect.js");
 const HTMLHint = require("htmlhint").default;
 
-const ruleId = "aka-must-be-spelt-correctly";
+const ruleId = "common-spelling-mistakes";
 
 const ruleOptions = {};
 
@@ -11,21 +11,21 @@ ruleOptions[ruleId] = true;
 
 describe(`Rules: ${ruleId}`, () => {
   addCustomHtmlRule();
-  it("aka used correctly should not result in an error", () => {
-    const code = "<p>aka</p>";
+  it("terms used correctly should not result in an error", () => {
+    const code = "<p>aka email cannot website username taskbar</p>";
     const messages = HTMLHint.verify(code, ruleOptions);
     expect(messages.length).to.be(0);
   });
 
-  it("aka used incorrectly should result in an error", () => {
-    const code = "<p>a.k.a A.K.A AKA</p>";
+  it("terms used incorrectly should result in an error", () => {
+    const code = "<p>a.k.a A.K.A AKA e-mail EMail can not web site user name task bar</p>";
     const messages = HTMLHint.verify(code, ruleOptions);
-    expect(messages.length).to.be(3);
+    expect(messages.length).to.be(9);
   });
 
   ["meta", "link", "script", "svg"].forEach((tag) => {
-    it(`aka in a <${tag}> tag should not result in an error`, () => {
-      const code = `<${tag}>a.k.a A.K.A AKA</${tag}>`;
+    it(`incorrect terms in a <${tag}> tag should not result in an error`, () => {
+      const code = `<${tag}>a.k.a A.K.A AKA e-mail EMail can not web site user name task bar</${tag}>`;
       const messages = HTMLHint.verify(code, ruleOptions);
       expect(messages.length).to.be(0);
     });

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -533,8 +533,8 @@ export const customHtmlHintRules = [
     type: RuleType.Warning
   },
   {
-    rule: "aka-must-be-spelt-correctly",
-    displayName: "Content - Use the correct spelling of \"aka\"",
+    rule: "common-spelling-mistakes",
+    displayName: "Content - Avoid common spelling and syntax mistakes",
     ruleLink: "https://www.ssw.com.au/rules/avoid-common-mistakes",
     type: RuleType.Warning
   },


### PR DESCRIPTION
https://github.com/SSWConsulting/SSW.CodeAuditor/issues/693

- Modified existing aka custom rule to include more spelling mistakes 
- Changed custom rule id to `common-spelling-mistakes`