### PR TITLE
Add new rule to check for phone numbers without hyperlinks

### DIFF
--- a/docker/api.js
+++ b/docker/api.js
@@ -163,4 +163,5 @@ exports.htmlHintConfig = {
   "detect-absolute-references-url-path-correctly": true,
   "use-unicode-hex-code-for-special-html-characters": true,
   "aka-must-be-spelt-correctly": true,
+  "phone-numbers-without-links": true,
 };

--- a/docker/package-lock.json
+++ b/docker/package-lock.json
@@ -20,6 +20,7 @@
 				"html5parser": "^1.2.1",
 				"htmlhint": "^0.11.0",
 				"js-beautify": "^1.14.9",
+				"libphonenumber-js": "^1.10.47",
 				"minimatch": "^3.1.2",
 				"mocha": "^9.2.2",
 				"node-fetch": "^2.6.12",
@@ -2945,6 +2946,11 @@
 			"engines": {
 				"node": ">= 0.8.0"
 			}
+		},
+		"node_modules/libphonenumber-js": {
+			"version": "1.10.47",
+			"resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.47.tgz",
+			"integrity": "sha512-b4t7VQDV29xx/ni+58yl9KWPGjnDLDXCeCTLrD4V8vDpObXZRZBrg7uX/HWZ7YXiJKqdBDGgc+barUUTNB6Slw=="
 		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",

--- a/docker/package.json
+++ b/docker/package.json
@@ -20,6 +20,7 @@
 		"html5parser": "^1.2.1",
 		"htmlhint": "^0.11.0",
 		"js-beautify": "^1.14.9",
+		"libphonenumber-js": "^1.10.47",
 		"minimatch": "^3.1.2",
 		"mocha": "^9.2.2",
 		"node-fetch": "^2.6.12",

--- a/docker/test/phone-numbers-without-links.js
+++ b/docker/test/phone-numbers-without-links.js
@@ -1,0 +1,56 @@
+const expect = require("expect.js");
+const HTMLHint = require("htmlhint").default;
+
+const ruleId = "phone-numbers-without-links";
+
+const ruleOptions = {};
+
+const { addCustomHtmlRule } = require("../customHtmlRules");
+
+ruleOptions[ruleId] = true;
+
+const phoneNumbers = [
+  "(213) 373-4253",
+  "(213)373-4253",
+  "213-373-4253",
+  "213.373.4253",
+  "2133734253",
+  "+12133734253",
+  "121-33734253",
+  "+61 2 9953 3000",
+  "+61299533000",
+  "+61 402 123 456"
+];
+
+describe(`Rules: ${ruleId}`, () => {
+  addCustomHtmlRule();
+
+  phoneNumbers.forEach((phone) => {
+    it(`text containing "${phone}" without hyperlink should error`, () => {
+      const code =
+      `<div>
+        <p>Call me here: ${phone}</p>
+      </div>`;
+      const messages = HTMLHint.verify(code, ruleOptions);
+      expect(messages.length).to.be(1);
+      expect(messages[0].line).to.be(2);
+    });
+  });
+
+  phoneNumbers.forEach((phone) => {
+    it(`link containing "${phone}" without hyperlink should error`, () => {
+      const code = `<a>${phone}</a>`;
+      const messages = HTMLHint.verify(code, ruleOptions);
+      expect(messages.length).to.be(1);
+      expect(messages[0].line).to.be(1);
+    });
+  });
+
+  phoneNumbers.forEach((phone) => {
+    it(`link containing "${phone}" with hyperlink should not error`, () => {
+      const code = `<a href=\"tel:${phone}\">${phone}</a>`;
+      const messages = HTMLHint.verify(code, ruleOptions);
+      expect(messages.length).to.be(0);
+    });
+  });
+});

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -545,6 +545,12 @@ export const customHtmlHintRules = [
     type: RuleType.Warning
   },
   {
+    rule: "phone-numbers-without-links",
+    displayName: "Content - Phone numbers must be in hyperlinks",
+    ruleLink: "https://www.ssw.com.au/rules/do-you-know-to-hyperlink-your-phone-numbers",
+    type: RuleType.Warning
+  },
+  {
     rule: "use-unicode-hex-code-for-special-html-characters",
     displayName: "Content - Use Unicode Hex code for special HTML characters",
     ruleLink: "https://ssw.com.au/rules/html-unicode-hex-codes/",


### PR DESCRIPTION
#694 

Adds a new rule to check if a phone number is not wrapped in a hyperlink with "tel:", as per https://www.ssw.com.au/rules/do-you-know-to-hyperlink-your-phone-numbers/