### PR TITLE
Add null check to broken links filter

### DIFF
--- a/docker/utils.js
+++ b/docker/utils.js
@@ -418,7 +418,7 @@ exports.processBrokenLinks = (
   const __getBadResults = (allUrls) =>
     allUrls
       // Allow successful 2xx status code range (200-299)
-      .filter((url) => url["StatusCode"].startsWith('2') && url["StatusCode"].length === 3)
+      .filter((url) => url["StatusCode"]?.startsWith('2') && url["StatusCode"]?.length === 3)
       .map((x) => ({
         src: x.Source || "",
         dst: x.Destination || "",


### PR DESCRIPTION
Small change to add a null check to the successful links filter as I noticed this can fail.

Might be related to recent scans failing #674

<img width="877" alt="Screenshot 2023-10-18 at 2 39 34 pm" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/df6b56e3-b51e-42d5-8bea-665c62380412">

**Figure: Error from recent scan**