### PR TITLE
Invert bad links filter

### DIFF
--- a/docker/utils.js
+++ b/docker/utils.js
@@ -418,7 +418,7 @@ exports.processBrokenLinks = (
   const __getBadResults = (allUrls) =>
     allUrls
       // Allow successful 2xx status code range (200-299)
-      .filter((url) => url["StatusCode"]?.startsWith('2') && url["StatusCode"]?.length === 3)
+      .filter((url) => !(url["StatusCode"]?.startsWith('2') && url["StatusCode"]?.length === 3))
       .map((x) => ({
         src: x.Source || "",
         dst: x.Destination || "",


### PR DESCRIPTION
I noticed the logic here is backwards and is reporting all good links as bad links, so this inverts it.