### PR TITLE
Sanitize strings before writing tab-delimited CSV

### DIFF
--- a/docker/sswlinkauditor.go
+++ b/docker/sswlinkauditor.go
@@ -208,10 +208,21 @@ func writeResultFile(allUrls map[string]LinkStatus) {
 
 	f.WriteString("Source" + "\t" + "Destination" + "\t" + "Status" + "\t" + "StatusCode" + "\t" + "Anchor" + "\n")
 	for _, v := range allUrls {
-		f.WriteString(v.srcUrl + "\t" + v.url + "\t" + v.status + "\t" + strconv.Itoa(v.statusCode) + "\t" + strings.ReplaceAll(v.anchor,"\"","") + "\n")
+		f.WriteString(sanitizeString(v.srcUrl) + "\t" + sanitizeString(v.url) + "\t" + sanitizeString(v.status) + "\t" + strconv.Itoa(v.statusCode) + "\t" + sanitizeString(v.anchor) + "\n")
 	}
 
 	f.Close()
+}
+
+func sanitizeString(s string) string {
+	replacer := strings.NewReplacer(
+		"\"", "",
+		"\t", " ",
+		"\r\n", "",
+		"\n", "",
+	);
+
+	return replacer.Replace(s);
 }
 
 func isLinkUnscannable(a string, unscannableLinks []string) bool {


### PR DESCRIPTION
Related to recent scans failing #674

This sanitises strings of tabs and newlines before writing the tab-delimited CSV file, as this can break the format.

<img width="896" alt="Screenshot 2023-10-19 at 12 10 15 pm" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/d9d24137-7a8b-4e6e-a4b8-cfa4e236bc10">

**Figure: A recent scan shows broken output attempting to read the CSV as the initial text contained newline characters**