### PR TITLE
Ensure all HTMLHint rules are uploaded against every scan

### DIFF
--- a/docker/index.js
+++ b/docker/index.js
@@ -28,6 +28,7 @@ const {
   runLighthouseReport,
   runArtilleryLoadTest
 } = require("./utils");
+const { htmlHintConfig } = require("./api");
 
 const LIGHTHOUSEFOLDER = "./lhr.json";
 const ARTILLERYFOLDER = "./artilleryOut.json";
@@ -315,7 +316,7 @@ const processAndUpload = async (
       });
     } catch (error) {
       console.error(
-        `Error: Unabled to push data to dashboard service => ${error.message}`
+        `Error: Unable to push data to dashboard service => ${error.message}`
       );
     }
   }
@@ -334,13 +335,13 @@ const processAndUpload = async (
   // Upload selected HTMLHint Rules to the scan
   if (args.htmlhint && args.token && runId) {
     const result = await getHTMLHintRules(args.token, args.url);
+    const selectedRules = result?.selectedRules ?? Object.keys(htmlHintConfig).join(",");
 
-    if (result && result.selectedRules?.split(",").length > 0) {
-      const selectedRules = result.selectedRules;
+    if (selectedRules?.length > 0) {
       const res = await addHTMLHintRulesForScan(args.token, args.url, runId, selectedRules)
   
       if (res) {
-        console.log('Upload selected HTMLHint Rules successfully')
+        console.log('Uploaded selected HTMLHint Rules successfully');
       } else {
         throw new Error("Failed to add custom html rules for each scan");
       }


### PR DESCRIPTION
#715 

This is a small fix to ensure that for every scan the HTMLHint rules it uses are always uploaded even if it wasn't previously configured. This will default to uploading all the default rules in the event there's no settings returned, as it gets scanned by these rules by default.

<img width="989" alt="Screenshot 2023-10-20 at 9 51 31 am" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/85f33480-1f6a-4fca-9c99-f00ba8f397bc">

**Figure: Scans now list the rules scanned even if these weren't previously configured (this was previously blank)**