### PR TITLE
Unscannable Links fixes

### DIFF
--- a/api/functions/consts.js
+++ b/api/functions/consts.js
@@ -24,29 +24,3 @@ exports.BLOB = {
 	htmlhint: 'htmlhint',
 	codeAuditor: 'codeauditor',
 };
-
-exports.unscannableLinks = [
-	{url: "https://learn.microsoft.com/en-us/"},
-	{url: "https://support.google.com/"},
-	{url: "https://twitter.com/"},
-	{url: "https://marketplace.visualstudio.com/"},
-	{url: "https://www.nuget.org/"},
-	{url: "https://make.powerautomate.com"},
-	{url: "https://www.microsoft.com/"},
-	{url: "http://www.microsoft.com/"},
-	{url: "https://answers.microsoft.com/"},
-	{url: "https://admin.microsoft.com/"},
-	{url: "https://ngrx.io"},
-	{url: "https://twitter.com"},
-	{url: "https://marketplace"},
-	{url: "https://www.nuget.org/"},
-	{url: "http://nuget.org"},
-	{url: "https://t.co"},
-	{url: "https://support.google.com"},
-	{url: "https://playwright.dev"},
-	{url: "https://www.theurlist.com/xamarinstreamers"},
-	{url: "https://dev.botframework.com"},
-	{url: "https://www.ssw.com.au/rules/rules-to-better-research-and-development/"},
-	{url: "https://www.ato.gov.au/Business/Research-and-development-tax-incentive/"},
-	{url: "https://learn.microsoft.com/en-us/assessments/?mode=home/"}
-  ]

--- a/api/functions/index.js
+++ b/api/functions/index.js
@@ -4,7 +4,6 @@ const admin = require('firebase-admin');
 const R = require('ramda');
 const fetch = require('node-fetch');
 const Queue = require('better-queue');
-const { unscannableLinks } = require('./consts');
 require('dotenv').config();
 
 const {
@@ -231,6 +230,7 @@ app.post('/scanresult/:api/:buildId', async (req, res) => {
 	const buildId = req.params.buildId;
 	const runId = newGuid();
 	const buildDate = new Date();
+	const unscannableLinks = await getUnscannableLinks();
 
 	const uid = await getUserIdFromApiKey(apikey);
 	if (!uid) {
@@ -262,11 +262,11 @@ app.post('/scanresult/:api/:buildId', async (req, res) => {
 		url,
 		cloc,
 		totalBrokenLinks: badUrls.length,
-		uniqueBrokenLinks: R.uniqBy(R.prop('dst'), badUrls.filter((x) => !unscannableLinks.some(link => x.dst.includes(link.url)))).length,
-		pagesWithBrokenLink: R.uniqBy(R.prop('src'), badUrls.filter((x) => !unscannableLinks.some(link => x.dst.includes(link.url)))).length,
+		uniqueBrokenLinks: R.uniqBy(R.prop('dst'), badUrls.filter((x) => !unscannableLinks.some(link => x.dst.includes(link)))).length,
+		pagesWithBrokenLink: R.uniqBy(R.prop('src'), badUrls.filter((x) => !unscannableLinks.some(link => x.dst.includes(link)))).length,
 		totalUnique404: R.uniqBy(
 			R.prop('dst'),
-			badUrls.filter((x) => x.statuscode === '404' && !unscannableLinks.some(link => x.dst.includes(link.url)))
+			badUrls.filter((x) => x.statuscode === '404' && !unscannableLinks.some(link => x.dst.includes(link)))
 		).length,
 		htmlWarnings: htmlWarnings ? htmlWarnings : 0,
 		htmlErrors: htmlErrors ? htmlErrors : 0,

--- a/api/functions/queries.js
+++ b/api/functions/queries.js
@@ -42,8 +42,8 @@ const getExistingBrokenLinkCount = async (runId) => {
 
     const existingCount = result.reduce((count, item) => {
         if (item.runId === runId) {
-            if (!previousFailures.has(item.dst) && !unscannableLinks.find((i) => item.dst.startsWith(i))) {
-				const hasPrevious = result.find((i) => i.dst === item.dst && i.buildDate < item.buildDate);
+            if (!previousFailures.has(item.dst) && !unscannableLinks.some((i) => item.dst.includes(i))) {
+				const hasPrevious = result.some((i) => i.dst === item.dst && i.buildDate < item.buildDate);
 				previousFailures.set(item.dst, hasPrevious);
                 
 				if (hasPrevious) {

--- a/ui/src/components/linkauditorcomponents/DetailsTable.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsTable.svelte
@@ -61,21 +61,7 @@
   }
 </style>
 
-{#if builds.length === 0}
-  <div class="mb-6 text-center text-xl py-8">
-    <Icon cssClass="inline-block">
-      <path
-        d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13
-        21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
-    </Icon>
-    No broken links in this build!
-    <Icon cssClass="inline-block">
-      <path
-        d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13
-        21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
-    </Icon>
-  </div>
-{:else}
+{#if builds.length}
   <div class="my-4">
     <div
       class="bggrey text-sm textgrey leading-none border-2 border-gray-200
@@ -115,7 +101,9 @@
       </button>
     </div>
   </div>
-  {#if foundUnscannableLinks.length > 0}
+{/if}
+{#if foundUnscannableLinks.length > 0}
+  <div class="my-4">
     <span class="font-bold mb-3">
       <Icon
           on:click={() => hideShow()}
@@ -128,39 +116,56 @@
         </Icon>
       Unscannable Links ({foundUnscannableLinks.length}):
     </span>
-    {#if !hiddenRows}
-      <span class="mb-3">
-        Some working links are reported as broken by CodeAuditor. They're marked as "unscannable". <a class="link hover:text-red-600" href="https://github.com/SSWConsulting/SSW.CodeAuditor/wiki/SSW-CodeAuditor-Knowledge-Base-(KB)#known-websites-that-has-anti-web-scraping-measures">Learn more on our KB.</a>
-      </span>
-      {#each foundUnscannableLinks as url}
-        <table 
-          class="table-fixed w-full md:table-auto mb-8"
-          in:fade={{ y: 100, duration: 400 }}
-          out:fade={{ y: -100, duration: 200 }}>
-          <tbody>
-            <tr>
-              <th class="table-header md:table-cell md:w-2/12 sm:px-4 py-2">Source</th>
-              <td class="w-10/12 border px-4 py-2 break-all">
-                <a class="inline-block align-baseline link" target="_blank" href={url.src}>{url.src}</a>
-              </td> 
-            </tr>
-          
-            <tr>
-              <th class="table-header md:table-cell w-2/12 sm:px-4 py-2">Anchor Text</th>
-              <td class="md:table-cell w-10/12 border px-4 py-2 break-all">{url.link || ''}</td>
-            </tr>
-            <tr>
-              <th class="table-header w-2/12 sm:px-4 py-2">Link</th> 
-              <td class="w-10/12 border px-4 py-2 break-all">
-                <a class="inline-block align-baseline link" target="_blank" href={url.dst}>{url.dst}</a>
-              </td>    
-            </tr>
-          </tbody>
-        </table>
-      {/each}
-    {/if}
+  </div>
+  {#if !hiddenRows}
+    <span class="mb-3">
+      Some working links are reported as broken by CodeAuditor. They're marked as "unscannable". <a class="link hover:text-red-600" href="https://github.com/SSWConsulting/SSW.CodeAuditor/wiki/SSW-CodeAuditor-Knowledge-Base-(KB)#known-websites-that-has-anti-web-scraping-measures">Learn more on our KB.</a>
+    </span>
+    {#each foundUnscannableLinks as url}
+      <table 
+        class="table-fixed w-full md:table-auto mb-8"
+        in:fade={{ y: 100, duration: 400 }}
+        out:fade={{ y: -100, duration: 200 }}>
+        <tbody>
+          <tr>
+            <th class="table-header md:table-cell md:w-2/12 sm:px-4 py-2">Source</th>
+            <td class="w-10/12 border px-4 py-2 break-all">
+              <a class="inline-block align-baseline link" target="_blank" href={url.src}>{url.src}</a>
+            </td> 
+          </tr>
+        
+          <tr>
+            <th class="table-header md:table-cell w-2/12 sm:px-4 py-2">Anchor Text</th>
+            <td class="md:table-cell w-10/12 border px-4 py-2 break-all">{url.link || ''}</td>
+          </tr>
+          <tr>
+            <th class="table-header w-2/12 sm:px-4 py-2">Link</th> 
+            <td class="w-10/12 border px-4 py-2 break-all">
+              <a class="inline-block align-baseline link" target="_blank" href={url.dst}>{url.dst}</a>
+            </td>    
+          </tr>
+        </tbody>
+      </table>
+    {/each}
   {/if}
+{/if}
+{#if !builds.length}
+  <div class="mb-6 text-center text-xl py-8">
+    <Icon cssClass="inline-block">
+      <path
+        d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13
+        21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+    </Icon>
+    No broken links in this build!
+    <Icon cssClass="inline-block">
+      <path
+        d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13
+        21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+    </Icon>
+  </div>
+{/if}
 
+{#if builds.length}
   {#if displayMode === 0}
     <DetailsBySource {builds} on:ignore />
   {:else if displayMode === 1}

--- a/ui/src/components/linkauditorcomponents/DetailsTable.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsTable.svelte
@@ -14,10 +14,10 @@
   export let unscannableLinks;
   
   let foundUnscannableLinks = [];
-  foundUnscannableLinks = builds.filter(build => unscannableLinks.some(link => build.dst.includes(link.url)));
+  foundUnscannableLinks = builds.filter(build => unscannableLinks.some(link => build.dst.includes(link)));
   
   // Filter out unscannable links
-  builds = builds.filter(build => !unscannableLinks.some(link => build.dst.includes(link.url)));
+  builds = builds.filter(build => !unscannableLinks.some(link => build.dst.includes(link)));
 
   let displayMode = 0;
 


### PR DESCRIPTION
#718

This updates the remaining code that was still using the hardcoded Unscannable Links list to instead use the API, and also ensure the Unscannable Links are always shown in the UI.