### PR TITLE
Fixed Clicking to view HTML error duplicates "display=1" in the route parameters

### DIFF
--- a/ui/src/components/htmlhintcomponents/HtmlErrorsByReason.svelte
+++ b/ui/src/components/htmlhintcomponents/HtmlErrorsByReason.svelte
@@ -123,7 +123,7 @@
                     cursor-default whitespace-nowrap">
                     <a
                       on:click={() => viewSource(page.url, item, error.error)}
-                      href={'#'}
+                      href={"javascript:void(0)"}
                       title="View source">
                       {item}
                     </a>
@@ -138,7 +138,7 @@
                         cursor-default whitespace-nowrap">
                         <a
                           on:click={() => viewSource(page.url, item, error.error)}
-                          href={'#'}
+                          href={"javascript:void(0)"}
                           title="View source">
                           {item}
                         </a>

--- a/ui/src/components/htmlhintcomponents/HtmlErrorsBySource.svelte
+++ b/ui/src/components/htmlhintcomponents/HtmlErrorsBySource.svelte
@@ -113,7 +113,7 @@
                     cursor-default whitespace-nowrap">
                     <a
                       on:click={() => viewSource(url.url, item, key)}
-                      href={'#'}
+                      href={"javascript:void(0)"}
                       title="View source">
                       {item}
                     </a>
@@ -128,7 +128,7 @@
                         cursor-default whitespace-nowrap">
                         <a
                           on:click={() => viewSource(url.url, item, key)}
-                          href={'#'}
+    s                      href={"javascript:void(0)"}
                           title="View source">
                           {item}
                         </a>

--- a/ui/src/components/htmlhintcomponents/HtmlErrorsBySource.svelte
+++ b/ui/src/components/htmlhintcomponents/HtmlErrorsBySource.svelte
@@ -128,7 +128,7 @@
                         cursor-default whitespace-nowrap">
                         <a
                           on:click={() => viewSource(url.url, item, key)}
-    s                      href={"javascript:void(0)"}
+                          href={"javascript:void(0)"}
                           title="View source">
                           {item}
                         </a>


### PR DESCRIPTION
https://github.com/SSWConsulting/SSW.CodeAuditor/issues/725

- Fixed Clicking to view HTML error duplicates "display=1" in the route parameters