### PR TITLE
Don't filter unscannable links in UI

### DIFF
--- a/api/functions/index.js
+++ b/api/functions/index.js
@@ -262,11 +262,11 @@ app.post('/scanresult/:api/:buildId', async (req, res) => {
 		url,
 		cloc,
 		totalBrokenLinks: badUrls.length,
-		uniqueBrokenLinks: R.uniqBy(R.prop('dst'), badUrls.filter((x) => !unscannableLinks.some(link => x.dst.includes(link)))).length,
-		pagesWithBrokenLink: R.uniqBy(R.prop('src'), badUrls.filter((x) => !unscannableLinks.some(link => x.dst.includes(link)))).length,
+		uniqueBrokenLinks: R.uniqBy(R.prop('dst'), badUrls).length,
+		pagesWithBrokenLink: R.uniqBy(R.prop('src'), badUrls).length,
 		totalUnique404: R.uniqBy(
 			R.prop('dst'),
-			badUrls.filter((x) => x.statuscode === '404' && !unscannableLinks.some(link => x.dst.includes(link)))
+			badUrls.filter((x) => x.statuscode === '404')
 		).length,
 		htmlWarnings: htmlWarnings ? htmlWarnings : 0,
 		htmlErrors: htmlErrors ? htmlErrors : 0,

--- a/docker/sswlinkauditor.go
+++ b/docker/sswlinkauditor.go
@@ -54,6 +54,7 @@ func check(link Link, linkch chan LinkStatus, number int, unscannableLinks []str
 	}
 	method := "HEAD"
 
+	// get list of links we consider unscannable and use a GET request to get a more accurate result
 	if isLinkUnscannable(link.url, unscannableLinks) {
 		method = "GET"
 	}

--- a/ui/src/containers/LinkReport.svelte
+++ b/ui/src/containers/LinkReport.svelte
@@ -12,7 +12,6 @@
   import LoadingFlat from "../components/misccomponents/LoadingFlat.svelte";
   import UpdateIgnoreUrl from "../components/misccomponents/UpdateIgnoreUrl.svelte";
   import BuildDetailsSlot from "../components/detailslotcomponents/BuildDetailsSlot.svelte";
-  import { CONSTS } from "../utils/utils";
 
   export let currentRoute;
 

--- a/ui/src/containers/LinkReport.svelte
+++ b/ui/src/containers/LinkReport.svelte
@@ -25,16 +25,12 @@
   if (currentRoute.namedParams.id) {
     promise = new Promise(async (resolve) => {
       const buildDetails = await getBuildDetails(currentRoute.namedParams.id);
-      const resp = await fetch(`${CONSTS.API}/api/unscannablelinks`);
-      const unscannableLinks = await resp.json();
-      resolve({ buildDetails, unscannableLinks });
+      resolve({ buildDetails });
     });
   } else {
     promise = new Promise(async (resolve) => {
       const buildDetails = await getLatestBuildDetails(currentRoute.namedParams.api, currentRoute.namedParams.url);
-      const resp = await fetch(`${CONSTS.API}/api/unscannablelinks`);
-      const unscannableLinks = await resp.json();
-      resolve({ buildDetails, unscannableLinks });
+      resolve({ buildDetails });
     });
   }
 
@@ -90,7 +86,7 @@
         on:ignore={url => showIgnore(data.buildDetails.summary.url, url, $userSession$)}
         builds={data.buildDetails ? data.buildDetails.brokenLinks : []}
         {currentRoute}
-        unscannableLinks={data.unscannableLinks} 
+        unscannableLinks={[]} 
       />
     </BuildDetailsSlot>
     {:catch error}


### PR DESCRIPTION
#730

This disables the UI filtering of unscannable links as these links should already be scanned with more accurate GET requests.

Not stripping it out completely just yet as we may revisit in the future if we change our HEAD/GET handling.

<img width="975" alt="Screenshot 2023-10-24 at 5 12 49 pm" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/45434647-cab2-4806-8306-63260d259f65">

**Figure: Links like these are now displayed accurately in the list**