### PR TITLE
Scan Compare fix

### DIFF
--- a/ui/src/components/summaryitemcomponents/CardSummary.svelte
+++ b/ui/src/components/summaryitemcomponents/CardSummary.svelte
@@ -86,7 +86,7 @@
       <button 
         type="button"
         class="bg-white hover:bg-gray-800 hover:text-white font-semibold py-2 px-4 border rounded"
-        on:click={navigateTo(`/scanCompare/${value.partitionKey}/${convertSpecialCharUrl(value.url.slice(12))}/${value.buildDate}`)}
+        on:click={navigateTo(`/scanCompare/${value.partitionKey}/${convertSpecialCharUrl(value.url)}/${value.buildDate}`)}
       >
         <i class="fas fa-code-compare"></i> 
         {previousScans[0].runId !== value.runId ? "Compare to latest scan" : "Compare to previous scan"}

--- a/ui/src/stores.js
+++ b/ui/src/stores.js
@@ -171,8 +171,7 @@ export const getLatestBuildDetails = async (api, url) => {
 };
 
 export const getAllScanSummaryFromUrl = async (api, url) => {
-	const fullUrl = `https%3A%2F%2Fwww.${url}` 
-	const res = await fetch(`${CONSTS.API}/api/scanSummaryFromUrl/${api}/${fullUrl}`);
+	const res = await fetch(`${CONSTS.API}/api/scanSummaryFromUrl/${api}/${url}`);
 	const result = await res.json();
 
 	if (res.ok) {


### PR DESCRIPTION
This is just a small fix for an issue I noticed with the Scan Compare page. The code is slicing out the first 12 characters of URLs assuming it contains "https://www" but since that's no longer normalised it breaks scan comparisons for URLs without "www." This just makes it always use the full URL.