### PR TITLE
Fixed spelling mistakes and scrum terms custom rule

### DIFF
--- a/docker/customHtmlRules.js
+++ b/docker/customHtmlRules.js
@@ -38,7 +38,7 @@ exports.addCustomHtmlRule = () => {
     init: function (parser, reporter) {
       var self = this;
 
-      parser.addListener("all", (event) => {
+      parser.addListener("text", (event) => {
         var scrumTerms = [
           "scrum",
           "sprint",
@@ -53,30 +53,33 @@ exports.addCustomHtmlRule = () => {
           "spec review"
         ];
 
-        if (event.tagName) {
-          if (event.tagName !== "a" && event.tagName !== "meta" && event.tagName !== "link" && event.tagName !== "script" && event.tagName !== "svg") { 
-            if (event.lastEvent) {
-              let pageContent = event.lastEvent.raw;
-              if (pageContent) {
-                scrumTerms.forEach((i) => {
-                  var contentIndex = pageContent.indexOf(i);
-                  var col = event.lastEvent.col;
-                  
-                  // Make sure the character has space and is not part of a long single string 
-                  if (pageContent.indexOf(' ') >= 0) {
-                    if (contentIndex >= 0) {
-                      reporter.warn(
-                        "Incorrect Scrum term: '" + i + "'.",
-                        event.line,
-                        col,
-                        self,
-                        event.raw
-                      );
-                    }
+        if (event.raw) {
+          const pageContent = event.raw;
+          if (event.lastEvent) {
+            if (
+              event.lastEvent.tagName !== "a" && 
+              event.lastEvent.tagName !== "meta" && 
+              event.lastEvent.tagName !== "link" && 
+              event.lastEvent.tagName !== "script" && 
+              event.lastEvent.tagName !== "svg"
+            ) {
+              scrumTerms.forEach((i) => {
+                var contentIndex = pageContent.indexOf(i);
+                
+                // Make sure the character has space and is not part of a long single string 
+                if (pageContent.indexOf(' ') >= 0) {
+                  if (contentIndex >= 0) {
+                    reporter.warn(
+                      "Incorrect Scrum term: '" + i + "'.",
+                      event.line,
+                      event.col,
+                      self,
+                      event.raw
+                    );
                   }
-                });
-              }
-            }    
+                }
+              });
+            }
           }
         }
       });
@@ -429,7 +432,7 @@ exports.addCustomHtmlRule = () => {
     init: function (parser, reporter) {
       var self = this;
 
-      parser.addListener("all", (event) => {
+      parser.addListener("text", (event) => {
         var spellings = [
           "a.k.a",
           "A.K.A",
@@ -442,29 +445,33 @@ exports.addCustomHtmlRule = () => {
           "task bar"
         ];
 
-        if (event.tagName) {
-          if (event.tagName !== "a" && event.tagName !== "meta" && event.tagName !== "link" && event.tagName !== "script" && event.tagName !== "svg") { 
-            if (event.lastEvent) {
-              let pageContent = event.lastEvent.raw;
-              if (pageContent) {
-                spellings.forEach((i) => {
-                  var contentIndex = pageContent.indexOf(i) >= 0;
-                  var col = event.lastEvent.col;
-                  // Make sure the character has space and is not part of a long single string 
-                  if (pageContent.indexOf(' ') >= 0) {
-                    if (contentIndex) {
-                      reporter.warn(
-                        "Incorrect spellings: '" + i + "'.",
-                        event.line,
-                        col,
-                        self,
-                        event.raw
-                      );
-                    }
+        if (event.raw) {
+          const pageContent = event.raw;
+          if (event.lastEvent) {
+            if (
+              event.lastEvent.tagName !== "a" && 
+              event.lastEvent.tagName !== "meta" && 
+              event.lastEvent.tagName !== "link" && 
+              event.lastEvent.tagName !== "script" && 
+              event.lastEvent.tagName !== "svg"
+            ) {
+              spellings.forEach((i) => {
+                var contentIndex = pageContent.indexOf(i);
+                
+                // Make sure the character has space and is not part of a long single string 
+                if (pageContent.indexOf(' ') >= 0) {
+                  if (contentIndex >= 0) {
+                    reporter.warn(
+                      "Incorrect terms: '" + i + "'.",
+                      event.line,
+                      event.col,
+                      self,
+                      event.raw
+                    );
                   }
-                });
-              }
-            }    
+                }
+              });
+            }
           }
         }
       });

--- a/docker/test/grammar-scrum-terms.spec.js
+++ b/docker/test/grammar-scrum-terms.spec.js
@@ -18,7 +18,7 @@ describe(`Rules: ${ruldId}`, () => {
     expect(messages.length).to.be(0);
   });
 
-  it("Scrum terms that are cased correctly should result in an error", () => {
+  it("Scrum terms that are cased incorrectly should result in an error", () => {
     const code =
       "<p>scrum, sprint, product owner, scrum master, product backlog, sprint review, sprint planning, sprint retrospective, sprint retro, specification review, spec review</p>";
     const messages = HTMLHint.verify(code, ruleOptions);
@@ -36,5 +36,13 @@ describe(`Rules: ${ruldId}`, () => {
       "<a href='sprint'>scrum, sprint, product owner</a>";
     const messages = HTMLHint.verify(code, ruleOptions);
     expect(messages.length).to.be(0);
+  });
+
+  ["a", "meta", "link", "script", "svg"].forEach((tag) => {
+    it(`incorrect terms in a <${tag}> tag should not result in an error`, () => {
+      const code = `<${tag}>scrum, sprint, product owner, scrum master, product backlog, sprint review, sprint planning, sprint retrospective, sprint retro, specification review, spec review</${tag}>`;
+      const messages = HTMLHint.verify(code, ruleOptions);
+      expect(messages.length).to.be(0);
+    });
   });
 });


### PR DESCRIPTION
https://github.com/SSWConsulting/SSW.CodeAuditor/issues/693

- Changing from listening "all" to "text" gives more accurate result
- Added another unit test case to check for tags in scrum terms rule