### PR TITLE
Fix scss editor warning

### DIFF
--- a/ui/src/global.scss
+++ b/ui/src/global.scss
@@ -1,8 +1,8 @@
 @import '../node_modules/github-markdown-css/github-markdown-light';
 @import '../node_modules/codemirror/lib/codemirror';
-@import 'tailwindcss/base';
-@import 'tailwindcss/components';
-@import 'tailwindcss/utilities';
+@import '../node_modules/tailwindcss/base';
+@import '../node_modules/tailwindcss/components';
+@import '../node_modules/tailwindcss/utilities';
 @import '../node_modules/@fortawesome/fontawesome-free/scss/fontawesome.scss';
 @import '../node_modules/@fortawesome/fontawesome-free/scss/solid.scss';
 


### PR DESCRIPTION
Just a small fix to resolve the editor complaining about not finding a stylesheet to load. It still loads regardless, but this just makes sure the editor doesn't warn about it.

<img width="630" alt="Screenshot 2023-11-01 at 10 30 09 am" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/6e0f16f4-fa74-4877-ad9f-337046bb91e0">

**Figure: Resolves this error in the editor**