### PR TITLE
Optimise getHTMLHintRulesByRunId by calling PartitionKey

### DIFF
--- a/api/functions/queries.js
+++ b/api/functions/queries.js
@@ -166,17 +166,17 @@ exports.getHTMLHintRules = (api, url, isGetAllRecords) =>
 		resolve(isGetAllRecords ? result : result[result.length - 1] || {})
   });
 
-exports.getHTMLHintRulesByRunId = (runId) => 
-	new Promise(async (resolve) => {
-		const entity = new TableClient(azureUrl, TABLE.htmlhintrules, credential).listEntities({
-			queryOptions: { filter: odata`RowKey eq ${runId}` }
-		});
-		let result = []
-		for await (const item of entity) {
-			result.push(item);
-		}
-		resolve(result[0] || {})
+exports.getHTMLHintRulesByRunId = async (runId) => {
+	const doc = await getRun(runId);
+	const entity = new TableClient(azureUrl, TABLE.htmlhintrules, credential).listEntities({
+		queryOptions: { filter: odata`PartitionKey eq ${doc.apikey} and RowKey eq ${runId}` }
 	});
+	let result = []
+	for await (const item of entity) {
+		result.push(item);
+	}
+	return result[0] || {};
+}
 
 exports.getPersonalSummary = (api, showAll) =>
 	new Promise(async (resolve) => {


### PR DESCRIPTION
Small tweak to optimise the getHTMLHintRulesByRunId function by also filtering on PartitionKey