### PR TITLE
Filter and sort on all results on Scan Results page

### DIFF
--- a/api/functions/queries.js
+++ b/api/functions/queries.js
@@ -219,9 +219,16 @@ exports.getAllPublicSummary = (showAll) =>
 				result.push(item);
 			}
 
-			resolve(result.filter((value, index, self) => {
-				return self.findIndex(v => v.runId === value.runId) === index;
-			}))
+			const seen = new Set();
+			const filteredResult = result.filter(value => {
+				if (seen.has(value.runId)) {
+					return false;
+				}
+				seen.add(value.runId);
+				return true;
+			})
+
+			resolve(filteredResult);
 		} else {
 			// Top 500 scans in last 12 months
 			var date = new Date();
@@ -235,13 +242,18 @@ exports.getAllPublicSummary = (showAll) =>
 				result.push(item);
 			}
 
-			const filteredResult = result.filter((value, index, self) => {
-				return self.findIndex(v => v.runId === value.runId) === index;
+			const seen = new Set();
+			const filteredResult = result.filter(value => {
+				if (seen.has(value.runId)) {
+					return false;
+				}
+				seen.add(value.runId);
+				return true;
 			})
 			.sort((a, b) => (a.rowKey > b.rowKey) ? 1 : -1)
 			.slice(0, parseInt(process.env.MAX_SCAN_SIZE));
 
-			resolve(filteredResult)
+			resolve(filteredResult);
 		}
 	});
 

--- a/api/functions/queries.js
+++ b/api/functions/queries.js
@@ -223,23 +223,25 @@ exports.getAllPublicSummary = (showAll) =>
 				return self.findIndex(v => v.runId === value.runId) === index;
 			}))
 		} else {
-			// Top 500 scans in last 24 months
+			// Top 500 scans in last 12 months
 			var date = new Date();
 			date.setMonth(date.getMonth() - 12);
 
 			const entity = new TableClient(azureUrl, TABLE.Scans, credential).listEntities({
 				queryOptions: { filter: odata`isPrivate eq ${false} and buildDate gt datetime'${date.toISOString()}'` }
 			});
-			const iterator = entity.byPage({ maxPageSize: parseInt(process.env.MAX_SCAN_SIZE) });
-			let result = [];
-			for await (const item of iterator) {
-				result = item;
-				break;
+			let result = []
+			for await (const item of entity) {
+				result.push(item);
 			}
 
-			resolve(result.filter((value, index, self) => {
+			const filteredResult = result.filter((value, index, self) => {
 				return self.findIndex(v => v.runId === value.runId) === index;
-			}))
+			})
+			.sort((a, b) => (a.rowKey > b.rowKey) ? 1 : -1)
+			.slice(0, parseInt(process.env.MAX_SCAN_SIZE));
+
+			resolve(filteredResult)
 		}
 	});
 


### PR DESCRIPTION
#760

This fixes an issue where the Public Scans list doesn't actually return the last 500 results as Table Storage is sorting based on PartitionKey first.