### PR TITLE
Fixed default value for internal link rule and Added loading spinner to card summary

### DIFF
--- a/docker/customHtmlRules.js
+++ b/docker/customHtmlRules.js
@@ -392,7 +392,7 @@ exports.addCustomHtmlRule = async (apiToken, url) => {
             if (customRuleOptions && customRuleOptions.length > 0 && customRuleOptions.filter(option => option.ruleId === ruleId).length > 0) {
               optionValue = customRuleOptions.find(option => option.ruleId === ruleId).optionValue
             }
-            if (mapAttrs["href"].startsWith(optionValue.length > 0 ? optionValue : "https://ssw.com.au/rules")) {
+            if (mapAttrs["href"].startsWith(optionValue.length > 0 ? optionValue : url)) {
               if (!mapAttrs["href"].startsWith("/")) {
               reporter.warn(
                 "URLs must be formatted to direct to a url path correctly.",

--- a/ui/src/components/summaryitemcomponents/CardSummary.svelte
+++ b/ui/src/components/summaryitemcomponents/CardSummary.svelte
@@ -8,6 +8,7 @@
   import { CONSTS } from "../../utils/utils";
   import { navigateTo } from "svelte-router-spa";
   import { onDestroy } from "svelte";
+  import LoadingFlat from "../misccomponents/LoadingFlat.svelte";
 
   export let value;
   export let isHtmlHintComp = false;
@@ -17,6 +18,7 @@
   let previousScans = [];
   let sharedEmailAddresses = [];
   let userApiKey;
+  let isLoading;
 
   const dispatch = createEventDispatcher();
   
@@ -37,9 +39,13 @@
   }
 
   const getPreviousScans = async () => {
+    isLoading = true;
     let fullUrl = convertSpecialCharUrl(value.url)
     const res = await fetch(`${CONSTS.API}/api/scanSummaryFromUrl/${userApiKey}/${fullUrl}`);
-    previousScans = await res.json();
+    if (res) {
+      previousScans = await res.json();
+      isLoading = false;
+    }
   };
 
   const userSubscriber = userSession$.subscribe(x => {
@@ -73,6 +79,9 @@
     </div>
   </div>
   <div class="text-center my-3">
+    {#if isLoading}
+      <LoadingFlat />
+    {/if}
     {#if previousScans.length > 1}
       {#if previousScans[0].runId !== value.runId}
         <button 


### PR DESCRIPTION
- Absolute internal link custom rule - Fixed default value to be the scan Url instead of hardcoded "ssw.com.au/rules"
- Added loading spinner when fetching previous data to display "Go to latest scan" or "Compare to previous scan" buttons