### PR TITLE
Fixed comparing scan directing to 404 page

### DIFF
--- a/ui/src/containers/ScanCompare.svelte
+++ b/ui/src/containers/ScanCompare.svelte
@@ -6,6 +6,7 @@
   import LoadingFlat from "../components/misccomponents/LoadingFlat.svelte";
   import { navigateTo } from "svelte-router-spa";
   import Breadcrumbs from "../components/misccomponents/Breadcrumbs.svelte";
+  import { revertSpecialCharUrl } from "../utils/utils";
 
   export let currentRoute;
   let allScans = [];
@@ -16,7 +17,7 @@
   onMount(async () => {
     allScans = await getAllScanSummaryFromUrl(
       currentRoute.namedParams.api,
-      currentRoute.namedParams.url
+      revertSpecialCharUrl(currentRoute.namedParams.url)
     );
 
     if (allScans.length > 0) {

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -351,6 +351,15 @@ export const convertSpecialCharUrl = (url) => {
   return url.replace(/[:/]/g, m => specialChars[m]);
 };
 
+export const revertSpecialCharUrl = (url) => {
+  // Replace special characters in URL string
+  const specialChars = {
+    '%3A' : ':',
+    '%2F' : '/'
+  };
+ return url.replace(/%3A|%2F/gi, (matched) => specialChars[matched]);
+};
+
 export const RuleType = {
   Warning: "Warning",
   Error: "Error",


### PR DESCRIPTION
This fixes an error when going to the scan compare page it always directs to 404 page. 
This is because on the ScanCompare component, the Url string for the compare scan API call is actually taken from the route parameter which includes special characters. The fix is simply to convert back the special characters to normal texts.