### PR TITLE
Disable Ignore checkboxes when loading

### DIFF
--- a/ui/src/components/htmlhintcomponents/HtmlErrorsByReason.svelte
+++ b/ui/src/components/htmlhintcomponents/HtmlErrorsByReason.svelte
@@ -64,6 +64,7 @@
     codeIssues && codeIssues.length > 0
       ? (getCodeErrorRules(codeIssues) || []).concat(HTMLERRORS)
       : HTMLERRORS;
+  $: isLoading = !!Object.keys(loadingChecks).length;
   $: {
     customHtmlRuleOptions.forEach((rule) => {
       const ignoredUrls = rule.ignoredUrls?.split(',').filter(i => i) || [];
@@ -192,7 +193,7 @@
               {#if loadingChecks[getKey(page.url, error.error)]}
                 <LoadingCircle />
               {:else}
-                <input type="checkbox" on:click={() => toggleIgnore(page.url, error.error)} bind:checked={ignoredChecks[getKey(page.url, error.error)]} />
+                <input type="checkbox" disabled={isLoading} on:click={() => toggleIgnore(page.url, error.error)} bind:checked={ignoredChecks[getKey(page.url, error.error)]} />
               {/if}
             </td>
           </tr>

--- a/ui/src/components/htmlhintcomponents/HtmlErrorsBySource.svelte
+++ b/ui/src/components/htmlhintcomponents/HtmlErrorsBySource.svelte
@@ -25,6 +25,7 @@
   
   $: allErrors = errors.concat(getCodeErrorsByFile(codeIssues));
   $: htmlHintIssues = getHtmlHintIssues(errors);
+  $: isLoading = !!Object.keys(loadingChecks).length;
   $: {
     customHtmlRuleOptions.forEach((rule) => {
       const ignoredUrls = rule.ignoredUrls?.split(',').filter(i => i) || [];
@@ -177,7 +178,7 @@
               {#if loadingChecks[getKey(url.url, key)]}
                 <LoadingCircle />
               {:else}
-                <input type="checkbox" on:click={() => toggleIgnore(url.url, key)} bind:checked={ignoredChecks[getKey(url.url, key)]} />
+                <input type="checkbox" disabled={isLoading} on:click={() => toggleIgnore(url.url, key)} bind:checked={ignoredChecks[getKey(url.url, key)]} />
               {/if}
             </td>
           </tr>


### PR DESCRIPTION
Small tweak to disable the Ignore checkboxes on code errors/warnings when loading as clicking multiple before one has finished leads to inconsistencies.