### PR TITLE
Add info icon to tooltips

### DIFF
--- a/ui/src/components/htmlhintcomponents/HtmlErrorsByReason.svelte
+++ b/ui/src/components/htmlhintcomponents/HtmlErrorsByReason.svelte
@@ -16,6 +16,7 @@
   import Icon from "../misccomponents/Icon.svelte";
   import { htmlHintRules, customHtmlHintRules } from "../../../../docker/rules.js";
   import LoadingCircle from "../misccomponents/LoadingCircle.svelte";
+  import { tooltip } from '../misccomponents/tooltip';
 
   export let errors = [];
   export let codeIssues = [];
@@ -136,7 +137,7 @@
         <tr>
           <th class="w-2/12 px-4 py-2">Page ({error.pages.length})</th>
           <th class="w-9/12 px-4 py-2">Locations (line:col)</th>
-          <th class="w-1/12 px-4 py-2">Ignore</th>
+          <th class="w-1/12 px-4 py-2" title="Ignore URL for this rule in future scans" use:tooltip>Ignore</th>
         </tr>
       </thead>
       <tbody>

--- a/ui/src/components/htmlhintcomponents/HtmlErrorsBySource.svelte
+++ b/ui/src/components/htmlhintcomponents/HtmlErrorsBySource.svelte
@@ -13,6 +13,7 @@
   import { createEventDispatcher } from "svelte";
   import Icon from "../misccomponents/Icon.svelte";
   import LoadingCircle from "../misccomponents/LoadingCircle.svelte";
+  import { tooltip } from '../misccomponents/tooltip';
 
   export let errors = [];
   export let codeIssues = [];
@@ -115,7 +116,7 @@
             Issues ({Object.keys(url.errors).length})
           </th>
           <th class="w-9/12 px-4 py-2">Locations</th>
-          <th class="w-1/12 px-4 py-2">Ignore</th>
+          <th class="w-1/12 px-4 py-2" title="Ignore rule on this URL in future scans" use:tooltip>Ignore</th>
         </tr>
       </thead>
       <tbody>

--- a/ui/src/components/misccomponents/TooltipFromAction.svelte
+++ b/ui/src/components/misccomponents/TooltipFromAction.svelte
@@ -1,19 +1,20 @@
 <script>
-	export let title;
-	export let x;
-	export let y;
+  export let title;
+  export let x;
+  export let y;
 </script>
-<div style="
-		top: {y + 5}px;
-		left: {x + 5}px;">{title}</div>
+
+<div style="top: {y + 5}px; left: {x + 5}px;">
+  <i class="fa-solid fa-circle-info text-blue-600"></i> {title}
+</div>
 
 <style>
-	div {
-		border: 1px solid #ddd;
-		box-shadow: 1px 1px 1px #ddd;
-		background: white;
-		border-radius: 4px;
-		padding: 4px;
-		position: absolute;
-	}
+  div {
+    border: 1px solid #ddd;
+    box-shadow: 1px 1px 1px #ddd;
+    background: white;
+    border-radius: 4px;
+    padding: 4px;
+    position: absolute;
+  }
 </style>


### PR DESCRIPTION
#792

Adds info icon to tooltip component

<img width="455" alt="Screenshot 2023-11-28 at 11 39 20 am" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/77fce483-6296-40f0-8b65-3efa2c9ef058">

**Figure: Tooltips have info icon in front**