### PR TITLE
Update ignored URL handling

### DIFF
--- a/api/functions/index.js
+++ b/api/functions/index.js
@@ -279,7 +279,7 @@ app.post('/scanresult/:api/:buildId', async (req, res) => {
 		...lhrSummary,
 		...atrSummary,
 		totalScanned,
-		whiteListed,
+		totalWhitelisted: whiteListed.length,
 		scanDuration,
 		url,
 		cloc,

--- a/docker/utils.js
+++ b/docker/utils.js
@@ -436,23 +436,21 @@ exports.processBrokenLinks = (
         whitelistedUrls
           .filter(
             (ig) =>
-              ig.ignoreOn === ignoreOn &&
+              (ig.ignoreOn === "all" || ig.ignoreOn === ignoreOn) &&
               (+ig.ignoreDuration === -1 ||
                 diffInDaysToNow(new Date(ig.effectiveFrom)) <
                   +ig.ignoreDuration)
           )
           .map((ig) => ig.urlToIgnore)
-          .filter((ignorePattern) => minimatch(url, ignorePattern)).length > 0
+          .filter((ignorePattern) => 
+            minimatch(url.src, ignorePattern) || minimatch(url.dst, ignorePattern)
+          ).length > 0
       );
     };
 
     // return the URL only
     const all = badUrls
-      .filter(
-        (url) =>
-          isInIgnoredList(url.dst, "all", whitelistedUrls) ||
-          isInIgnoredList(url.dst, startUrl, whitelistedUrls)
-      )
+      .filter((url) => isInIgnoredList(url, startUrl))
       .map((x) => x.dst);
     return [...new Set(all)];
   };

--- a/ui/src/components/linkauditorcomponents/DetailsByDest.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsByDest.svelte
@@ -11,6 +11,7 @@
   const dispatch = createEventDispatcher();
 
   export let builds = [];
+  export let scanUrl;
 
   const ignore = url => dispatch("ignore", url);
   let destinations;
@@ -25,7 +26,7 @@
     destinationsKeys = Object.keys(destinations);
 
     ignoredChecks = builds.reduce((acc, val) => {
-      acc[val.dst] = isInIgnored(val, $ignoredUrls$);
+      acc[val.dst] = isInIgnored(val, scanUrl, $ignoredUrls$);
       return acc;
     }, {});
   }
@@ -47,7 +48,7 @@
   const deleteIgnore = async (url) => {
     deleteUrl = url;
     loadingChecks[url] = true;
-    const rules = getMatchingIgnoredRules(url, $ignoredUrls$);
+    const rules = getMatchingIgnoredRules(url, scanUrl, $ignoredUrls$);
     try {
       for await (const rule of rules) {
         await deleteIgnoreUrl(rule, $userSession$);

--- a/ui/src/components/linkauditorcomponents/DetailsByDest.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsByDest.svelte
@@ -25,7 +25,7 @@
     destinationsKeys = Object.keys(destinations);
 
     ignoredChecks = builds.reduce((acc, val) => {
-      acc[val.dst] = isInIgnored(val.dst, $ignoredUrls$);
+      acc[val.dst] = isInIgnored(val, $ignoredUrls$);
       return acc;
     }, {});
   }

--- a/ui/src/components/linkauditorcomponents/DetailsByReason.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsByReason.svelte
@@ -12,6 +12,8 @@
   const dispatch = createEventDispatcher();
   const ignore = url => dispatch("ignore", url);
 
+  export let scanUrl;
+
   let reasons;
   let reasonsKeys = [];
   let hiddenRows = {};
@@ -25,7 +27,7 @@
     reasonsKeys = Object.keys(reasons);
 
     ignoredChecks = builds.reduce((acc, val) => {
-      acc[val.dst] = isInIgnored(val, $ignoredUrls$);
+      acc[val.dst] = isInIgnored(val, scanUrl, $ignoredUrls$);
       return acc;
     }, {});
   }
@@ -46,7 +48,7 @@
   const deleteIgnore = async (url) => {
     deleteUrl = url;
     loadingChecks[url] = true;
-    const rules = getMatchingIgnoredRules(url, $ignoredUrls$);
+    const rules = getMatchingIgnoredRules(url, scanUrl, $ignoredUrls$);
     try {
       for await (const rule of rules) {
         await deleteIgnoreUrl(rule, $userSession$);

--- a/ui/src/components/linkauditorcomponents/DetailsByReason.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsByReason.svelte
@@ -25,7 +25,7 @@
     reasonsKeys = Object.keys(reasons);
 
     ignoredChecks = builds.reduce((acc, val) => {
-      acc[val.dst] = isInIgnored(val.dst, $ignoredUrls$);
+      acc[val.dst] = isInIgnored(val, $ignoredUrls$);
       return acc;
     }, {});
   }

--- a/ui/src/components/linkauditorcomponents/DetailsBySource.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsBySource.svelte
@@ -23,7 +23,7 @@
     sources = groupBy(props(["src"]))(builds);
     sourcesKeys = Object.keys(sources);
     ignoredChecks = builds.reduce((acc, val) => {
-      acc[val.dst] = isInIgnored(val.dst, $ignoredUrls$);
+      acc[val.dst] = isInIgnored(val, $ignoredUrls$);
       return acc;
     }, {});
   }

--- a/ui/src/components/linkauditorcomponents/DetailsBySource.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsBySource.svelte
@@ -12,6 +12,8 @@
   const dispatch = createEventDispatcher();
   const ignore = url => dispatch("ignore", url);
 
+  export let scanUrl;
+
   let sources;
   let sourcesKeys = [];
   let ignoredChecks = {};
@@ -23,7 +25,7 @@
     sources = groupBy(props(["src"]))(builds);
     sourcesKeys = Object.keys(sources);
     ignoredChecks = builds.reduce((acc, val) => {
-      acc[val.dst] = isInIgnored(val, $ignoredUrls$);
+      acc[val.dst] = isInIgnored(val, scanUrl, $ignoredUrls$);
       return acc;
     }, {});
   }
@@ -45,7 +47,7 @@
   const deleteIgnore = async (url) => {
     deleteUrl = url;
     loadingChecks[url] = true;
-    const rules = getMatchingIgnoredRules(url, $ignoredUrls$);
+    const rules = getMatchingIgnoredRules(url, scanUrl, $ignoredUrls$);
     try {
       for await (const rule of rules) {
         await deleteIgnoreUrl(rule, $userSession$);

--- a/ui/src/components/linkauditorcomponents/DetailsTable.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsTable.svelte
@@ -12,6 +12,7 @@
   export let builds = [];
   export let currentRoute;
   export let unscannableLinks;
+  export let scanUrl;
   
   let foundUnscannableLinks = [];
   foundUnscannableLinks = builds.filter(build => unscannableLinks.some(link => build.dst.includes(link)));
@@ -167,10 +168,10 @@
 
 {#if builds.length}
   {#if displayMode === 0}
-    <DetailsBySource {builds} on:ignore />
+    <DetailsBySource {builds} {scanUrl} on:ignore />
   {:else if displayMode === 1}
-    <DetailsByDest {builds} on:ignore />
+    <DetailsByDest {builds} {scanUrl} on:ignore />
   {:else}
-    <DetailsByReason {builds} on:ignore />
+    <DetailsByReason {builds} {scanUrl} on:ignore />
   {/if}
 {/if}

--- a/ui/src/components/misccomponents/UpdateIgnoreUrl.svelte
+++ b/ui/src/components/misccomponents/UpdateIgnoreUrl.svelte
@@ -152,7 +152,7 @@
               class="hidden"
               id="radio2"
               bind:group={ignoreOn}
-              value={url}
+              value={scanUrl}
               disabled={editing}
             />
             <label for="radio2" class:disabled={editing} class="flex items-center">

--- a/ui/src/containers/LinkReport.svelte
+++ b/ui/src/containers/LinkReport.svelte
@@ -85,7 +85,8 @@
         on:ignore={url => showIgnore(data.buildDetails.summary.url, url, $userSession$)}
         builds={data.buildDetails ? data.buildDetails.brokenLinks : []}
         {currentRoute}
-        unscannableLinks={[]} 
+        unscannableLinks={[]}
+        scanUrl={data.buildDetails.summary.url}
       />
     </BuildDetailsSlot>
     {:catch error}

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -126,15 +126,15 @@ export const getLoadThresholdResult = (value) => ({
   errors: value.errors,
 });
 
-export const isInIgnored = (url, list) => {
-  return getMatchingIgnoredRules(url, list).length > 0;
+export const isInIgnored = (url, scanUrl, list) => {
+  return getMatchingIgnoredRules(url, scanUrl, list).length > 0;
 };
 
-export const getMatchingIgnoredRules = (url, list) => {
+export const getMatchingIgnoredRules = (url, scanUrl, list) => {
   const date = new Date();
   return list.filter((item) => {
     const pattern = item.urlToIgnore;
-    if (globMatchUrl(pattern, url.src) || globMatchUrl(pattern, url.dst)) {
+    if ((item.ignoreOn === "all" || item.ignoreOn === scanUrl) && (globMatchUrl(pattern, url.src) || globMatchUrl(pattern, url.dst))) {
       const effectiveFrom = new Date(item.effectiveFrom);
       const timeElapsed = (date - effectiveFrom) / 86400000;
       return (item.ignoreDuration > 0 && timeElapsed < item.ignoreDuration) || item.ignoreDuration === -1;

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -134,7 +134,7 @@ export const getMatchingIgnoredRules = (url, list) => {
   const date = new Date();
   return list.filter((item) => {
     const pattern = item.urlToIgnore;
-    if (globMatchUrl(pattern, url)) {
+    if (globMatchUrl(pattern, url.src) || globMatchUrl(pattern, url.dst)) {
       const effectiveFrom = new Date(item.effectiveFrom);
       const timeElapsed = (date - effectiveFrom) / 86400000;
       return (item.ignoreDuration > 0 && timeElapsed < item.ignoreDuration) || item.ignoreDuration === -1;


### PR DESCRIPTION
1. Updates the ignored URL handling to also check against source URLs in addition to destination URLs, which allows us for example to ignore "/people" and "/rules" links on our home website.
2. Prevents uploading the full whitelisted URL list to our Scan data as large amounts of data causes this to error and we're not using this list anyway.
3. Fixes an issue where the wrong source URL is uploaded in the Ignore modal.