### PR TITLE
Add basic filtering to scan results page

### DIFF
--- a/ui/src/components/linkauditorcomponents/DetailsByDest.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsByDest.svelte
@@ -12,6 +12,7 @@
 
   export let builds = [];
   export let scanUrl;
+  export let isIgnoredHidden;
 
   const ignore = url => dispatch("ignore", url);
   let destinations;
@@ -47,7 +48,7 @@
 
   const deleteIgnore = async (url) => {
     deleteUrl = url;
-    loadingChecks[url] = true;
+    loadingChecks[url.dst] = true;
     const rules = getMatchingIgnoredRules(url, scanUrl, $ignoredUrls$);
     try {
       for await (const rule of rules) {
@@ -56,82 +57,84 @@
     } catch (error) {
       addedFailedToast = true;
     } finally {
-      loadingChecks[url] = false;
+      loadingChecks[url.dst] = false;
     }
   };
 
   const toggleIgnore = async (url) => {
-    if (ignoredChecks[url]) {
+    if (ignoredChecks[url.dst]) {
       await deleteIgnore(url);
     } else {
-      ignore(url);
+      ignore(url.dst);
     }
   };
 </script>
 
 {#each destinationsKeys as url}
-  <div class="mb-3">
-    <span class="font-bold mr-2">
-      <Icon
-        cssClass="inline-block cursor-pointer"
-        on:click={() => hideShow(url)}>
-        {#if !hiddenRows[url]}
-          <path d="M19 9l-7 7-7-7" />
-        {:else}
-          <path d="M9 5l7 7-7 7" />
-        {/if}
-      </Icon>
-      {destinations[url][0].statusmsg} ({destinations[url][0].statuscode || 0})
-      :
-    </span>
-    <a class="mr-2 inline-block align-baseline link" target="_blank" href={url}>
-      {url}
-    </a>
-  </div>
-  {#if !hiddenRows[url]}
-    <div class="font-bold textgrey ml-2">
-      <i class="fas fa-ban"></i>
-      <span title="Ignore URL in future scans" use:tooltip>Ignore: </span>
-      {#if loadingChecks[url]}
-        <LoadingCircle />
-      {:else}
-        <input type="checkbox" on:click={() => toggleIgnore(url)} bind:checked={ignoredChecks[url]} />
-      {/if}
+  {#if !(isIgnoredHidden && ignoredChecks[url])}
+    <div class="mb-3">
+      <span class="font-bold mr-2">
+        <Icon
+          cssClass="inline-block cursor-pointer"
+          on:click={() => hideShow(url)}>
+          {#if !hiddenRows[url]}
+            <path d="M19 9l-7 7-7-7" />
+          {:else}
+            <path d="M9 5l7 7-7 7" />
+          {/if}
+        </Icon>
+        {destinations[url][0].statusmsg} ({destinations[url][0].statuscode || 0})
+        :
+      </span>
+      <a class="mr-2 inline-block align-baseline link" target="_blank" href={url}>
+        {url}
+      </a>
     </div>
-    {#if destinations[url][0].daysUnfixed > -1}
-      <div class="font-bold text-yellow-600 ml-2">
-        <i class="fas fa-exclamation-triangle"></i>
-        {formatDaysUnfixed(destinations[url][0].daysUnfixed)}
+    {#if !hiddenRows[url]}
+      <div class="font-bold textgrey ml-2">
+        <i class="fas fa-ban"></i>
+        <span title="Ignore URL in future scans" use:tooltip>Ignore: </span>
+        {#if loadingChecks[url]}
+          <LoadingCircle />
+        {:else}
+          <input type="checkbox" on:click={() => toggleIgnore(url)} bind:checked={ignoredChecks[url]} />
+        {/if}
       </div>
-    {/if}
-    <table
-      class="table-fixed w-full md:table-auto mb-8"
-      in:fade={{ y: 100, duration: 400 }}
-      out:fade={{ y: -100, duration: 200 }}>
-      <thead>
-        <tr>
-          <th class="w-6/12 px-4 py-2">
-            Found on Page ({destinations[url].length})
-          </th>
-          <th class="w-6/12 px-4 py-2">Anchor Text</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each destinations[url] as val}
+      {#if destinations[url][0].daysUnfixed > -1}
+        <div class="font-bold text-yellow-600 ml-2">
+          <i class="fas fa-exclamation-triangle"></i>
+          {formatDaysUnfixed(destinations[url][0].daysUnfixed)}
+        </div>
+      {/if}
+      <table
+        class="table-fixed w-full md:table-auto mb-8"
+        in:fade={{ y: 100, duration: 400 }}
+        out:fade={{ y: -100, duration: 200 }}>
+        <thead>
           <tr>
-            <td class="w-6/12 border px-4 py-2 break-all">
-              <a
-                class="link inline-block align-baseline link"
-                target="_blank"
-                href={val.src}>
-                {val.src}
-              </a>
-            </td>
-            <td class="w-6/12 border px-4 py-2 break-all">{val.link || ''}</td>
+            <th class="w-6/12 px-4 py-2">
+              Found on Page ({destinations[url].length})
+            </th>
+            <th class="w-6/12 px-4 py-2">Anchor Text</th>
           </tr>
-        {/each}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {#each destinations[url] as val}
+            <tr>
+              <td class="w-6/12 border px-4 py-2 break-all">
+                <a
+                  class="link inline-block align-baseline link"
+                  target="_blank"
+                  href={val.src}>
+                  {val.src}
+                </a>
+              </td>
+              <td class="w-6/12 border px-4 py-2 break-all">{val.link || ''}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
   {/if}
 {/each}
 

--- a/ui/src/components/linkauditorcomponents/DetailsByReason.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsByReason.svelte
@@ -8,11 +8,13 @@
   import LoadingCircle from "../misccomponents/LoadingCircle.svelte";
   import Toastr from "../misccomponents/Toastr.svelte";
   import { tooltip } from '../misccomponents/tooltip';
+
   export let builds = [];
+  export let scanUrl;
+  export let isIgnoredHidden;
+
   const dispatch = createEventDispatcher();
   const ignore = url => dispatch("ignore", url);
-
-  export let scanUrl;
 
   let reasons;
   let reasonsKeys = [];
@@ -22,7 +24,7 @@
   let deleteUrl = '';
   let addedFailedToast = false;
 
-  $: if (builds.length > 0) {
+  $: {
     reasons = groupBy(props(["statusmsg"]))(builds);
     reasonsKeys = Object.keys(reasons);
 
@@ -47,7 +49,7 @@
 
   const deleteIgnore = async (url) => {
     deleteUrl = url;
-    loadingChecks[url] = true;
+    loadingChecks[url.dst] = true;
     const rules = getMatchingIgnoredRules(url, scanUrl, $ignoredUrls$);
     try {
       for await (const rule of rules) {
@@ -56,88 +58,92 @@
     } catch (error) {
       addedFailedToast = true;
     } finally {
-      loadingChecks[url] = false;
+      loadingChecks[url.dst] = false;
     }
   };
 
   const toggleIgnore = async (url) => {
-    if (ignoredChecks[url]) {
+    if (ignoredChecks[url.dst]) {
       await deleteIgnore(url);
     } else {
-      ignore(url);
+      ignore(url.dst);
     }
   };
 </script>
 
 {#each reasonsKeys as reason}
-  <div class="mb-3">
-    <span class="font-bold mr-2">
-      <Icon
-        cssClass="inline-block cursor-pointer"
-        on:click={() => hideShow(reason)}>
-        {#if !hiddenRows[reason]}
-          <path d="M19 9l-7 7-7-7" />
-        {:else}
-          <path d="M9 5l7 7-7 7" />
-        {/if}
-      </Icon>
-      Failure reason:
-    </span>
-    <span class="inline-block align-baseline textgrey">{reason}</span>
-  </div>
+  {#if !(isIgnoredHidden && reasons[reason].every((val) => ignoredChecks[val.dst]))}
+    <div class="mb-3">
+      <span class="font-bold mr-2">
+        <Icon
+          cssClass="inline-block cursor-pointer"
+          on:click={() => hideShow(reason)}>
+          {#if !hiddenRows[reason]}
+            <path d="M19 9l-7 7-7-7" />
+          {:else}
+            <path d="M9 5l7 7-7 7" />
+          {/if}
+        </Icon>
+        Failure reason:
+      </span>
+      <span class="inline-block align-baseline textgrey">{reason}</span>
+    </div>
 
-  {#if !hiddenRows[reason]}
-    <table
-      class="w-full table-auto mb-8"
-      in:fade={{ y: 100, duration: 400 }}
-      out:fade={{ y: -100, duration: 200 }}>
-      <thead>
-        <tr>
-          <th class="w-4/12 px-2 py-2">Source ({reasons[reason].length})</th>
-          <th class="w-3/12 px-2 py-2">Destination</th>
-          <th class="w-2/12 px-2 py-2">Anchor Text</th>
-          <th class="w-1/12 px-2 py-2 text-right">Status</th>
-          <th class="w-1/12 px-2 py-2 text-right">Days Unfixed</th>
-          <th class="hidden md:table-cell w-1/12 px-2 py-2" title="Ignore URL in future scans" use:tooltip>Ignore</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each reasons[reason] as val}
+    {#if !hiddenRows[reason]}
+      <table
+        class="w-full table-auto mb-8"
+        in:fade={{ y: 100, duration: 400 }}
+        out:fade={{ y: -100, duration: 200 }}>
+        <thead>
           <tr>
-            <td class="w-4/12 border px-2 py-2 break-all">
-              <a
-                class="inline-block align-baseline link"
-                target="_blank"
-                href={val.src}>
-                {val.src}
-              </a>
-            </td>
-            <td class="w-3/12 border px-2 py-2 break-all">
-              <a
-                class="inline-block align-baseline link"
-                target="_blank"
-                href={val.dst}>
-                {val.dst.length < 70 ? val.dst : val.dst.substring(0, 70) + '...'}
-              </a>
-            </td>
-            <td class="w-2/12 border px-2 py-2 break-all">{val.link || ''}</td>
-            <td class="w-1/12 border px-2 py-2 text-right">
-              {val.statuscode || '0'}
-            </td>
-            <td class="w-1/12 border px-2 py-2 text-right">
-              {formatDaysUnfixed(val.daysUnfixed)}
-            </td>
-            <td class="hidden md:table-cell w-1/12 border px-2 py-2 text-center">
-              {#if loadingChecks[val.dst]}
-                <LoadingCircle />
-              {:else}
-                <input type="checkbox" on:click={() => toggleIgnore(val.dst)} bind:checked={ignoredChecks[val.dst]} />
-              {/if}
-            </td>
+            <th class="w-4/12 px-2 py-2">Source ({reasons[reason].length})</th>
+            <th class="w-3/12 px-2 py-2">Destination</th>
+            <th class="w-2/12 px-2 py-2">Anchor Text</th>
+            <th class="w-1/12 px-2 py-2 text-right">Status</th>
+            <th class="w-1/12 px-2 py-2 text-right">Days Unfixed</th>
+            <th class="hidden md:table-cell w-1/12 px-2 py-2" title="Ignore URL in future scans" use:tooltip>Ignore</th>
           </tr>
-        {/each}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {#each reasons[reason] as val}
+            {#if !(isIgnoredHidden && ignoredChecks[val.dst])}
+              <tr>
+                <td class="w-4/12 border px-2 py-2 break-all">
+                  <a
+                    class="inline-block align-baseline link"
+                    target="_blank"
+                    href={val.src}>
+                    {val.src}
+                  </a>
+                </td>
+                <td class="w-3/12 border px-2 py-2 break-all">
+                  <a
+                    class="inline-block align-baseline link"
+                    target="_blank"
+                    href={val.dst}>
+                    {val.dst.length < 70 ? val.dst : val.dst.substring(0, 70) + '...'}
+                  </a>
+                </td>
+                <td class="w-2/12 border px-2 py-2 break-all">{val.link || ''}</td>
+                <td class="w-1/12 border px-2 py-2 text-right">
+                  {val.statuscode || '0'}
+                </td>
+                <td class="w-1/12 border px-2 py-2 text-right">
+                  {formatDaysUnfixed(val.daysUnfixed)}
+                </td>
+                <td class="hidden md:table-cell w-1/12 border px-2 py-2 text-center">
+                  {#if loadingChecks[val.dst]}
+                    <LoadingCircle />
+                  {:else}
+                    <input type="checkbox" on:click={() => toggleIgnore(val.dst)} bind:checked={ignoredChecks[val.dst]} />
+                  {/if}
+                </td>
+              </tr>
+            {/if}
+          {/each}
+        </tbody>
+      </table>
+    {/if}
   {/if}
 {/each}
 

--- a/ui/src/components/linkauditorcomponents/DetailsBySource.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsBySource.svelte
@@ -3,16 +3,18 @@
   import { isInIgnored, getMatchingIgnoredRules } from "../../utils/utils.js";
   import { fade } from "svelte/transition";
   import { ignoredUrls$, deleteIgnoreUrl, userSession$ } from "../../stores.js";
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, onMount } from "svelte";
   import Icon from "../misccomponents/Icon.svelte";
   import LoadingCircle from "../misccomponents/LoadingCircle.svelte";
   import Toastr from "../misccomponents/Toastr.svelte";
   import { tooltip } from '../misccomponents/tooltip';
+
   export let builds = [];
+  export let scanUrl;
+  export let isIgnoredHidden;
+
   const dispatch = createEventDispatcher();
   const ignore = url => dispatch("ignore", url);
-
-  export let scanUrl;
 
   let sources;
   let sourcesKeys = [];
@@ -21,13 +23,14 @@
   let deleteUrl = '';
   let addedFailedToast = false;
 
-  $: if (builds.length > 0) {
+  $: {
     sources = groupBy(props(["src"]))(builds);
     sourcesKeys = Object.keys(sources);
+
     ignoredChecks = builds.reduce((acc, val) => {
-      acc[val.dst] = isInIgnored(val, scanUrl, $ignoredUrls$);
-      return acc;
-    }, {});
+        acc[val.dst] = isInIgnored(val, scanUrl, $ignoredUrls$);
+        return acc;
+      }, {});
   }
 
   let hiddenRows = {};
@@ -46,7 +49,7 @@
 
   const deleteIgnore = async (url) => {
     deleteUrl = url;
-    loadingChecks[url] = true;
+    loadingChecks[url.dst] = true;
     const rules = getMatchingIgnoredRules(url, scanUrl, $ignoredUrls$);
     try {
       for await (const rule of rules) {
@@ -55,83 +58,87 @@
     } catch (error) {
       addedFailedToast = true;
     } finally {
-      loadingChecks[url] = false;
+      loadingChecks[url.dst] = false;
     }
   };
 
   const toggleIgnore = async (url) => {
-    if (ignoredChecks[url]) {
+    if (ignoredChecks[url.dst]) {
       await deleteIgnore(url);
     } else {
-      ignore(url);
+      ignore(url.dst);
     }
   };
 </script>
 
 {#each sourcesKeys as url}
-  <div class="mb-3">
-    <span class="font-bold">
-      <Icon
-        on:click={() => hideShow(url)}
-        cssClass="inline-block cursor-pointer">
-        {#if !hiddenRows[url]}
-          <path d="M19 9l-7 7-7-7" />
-        {:else}
-          <path d="M9 5l7 7-7 7" />
-        {/if}
-      </Icon>
-      Broken links on:
-    </span>
-    <a class="inline-block align-baseline link" target="_blank" href={url}>{url}</a>
-  </div>
-  {#if !hiddenRows[url]}
-    <table
-      class="table-fixed w-full table-auto mb-8"
-      in:fade={{ y: 100, duration: 400 }}
-      out:fade={{ y: -100, duration: 200 }}>
-      <thead>
-        <tr>
-          <th class="w-5/12 px-2 py-2">Broken Link ({sources[url].length})</th>
-          <th class="hidden md:table-cell w-2/12 px-2 py-2">Anchor Text</th>
-          <th class="w-1/12 px-2 py-2 text-right">Status</th>
-          <th class="hidden md:table-cell w-2/12 px-2 py-2 text-right">Message</th>
-          <th class="hidden md:table-cell w-1/12 px-2 py-2 text-right">Days Unfixed</th>
-          <th class="hidden md:table-cell w-1/12 px-2 py-2" title="Ignore URL in future scans" use:tooltip>Ignore</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each sources[url] as val}
+  {#if !(isIgnoredHidden && sources[url].every((val) => ignoredChecks[val.dst]))}
+    <div class="mb-3">
+      <span class="font-bold">
+        <Icon
+          on:click={() => hideShow(url)}
+          cssClass="inline-block cursor-pointer">
+          {#if !hiddenRows[url]}
+            <path d="M19 9l-7 7-7-7" />
+          {:else}
+            <path d="M9 5l7 7-7 7" />
+          {/if}
+        </Icon>
+        Broken links on:
+      </span>
+      <a class="inline-block align-baseline link" target="_blank" href={url}>{url}</a>
+    </div>
+    {#if !hiddenRows[url]}
+      <table
+        class="table-fixed w-full table-auto mb-8"
+        in:fade={{ y: 100, duration: 400 }}
+        out:fade={{ y: -100, duration: 200 }}>
+        <thead>
           <tr>
-            <td class="w-5/12 border px-2 py-2 break-all">
-              <a
-                class="inline-block align-baseline link"
-                target="_blank"
-                href={val.dst}>
-                {val.dst.length < 70 ? val.dst : val.dst.substring(0, 70) + '...'}
-              </a>
-
-            </td>
-            <td class="hidden md:table-cell w-2/12 border px-2 py-2 break-all">{val.link || ''}</td>
-            <td class="w-1/12 border px-2 py-2 text-right">
-              {val.statuscode || '0'}
-            </td>
-            <td class="hidden md:table-cell w-2/12 border px-2 py-2 text-right">
-              {val.statusmsg || ''}
-            </td>
-            <td class="hidden md:table-cell w-1/12 border px-2 py-2 text-right">
-              {formatDaysUnfixed(val.daysUnfixed)}
-            </td>
-            <td class="hidden md:table-cell w-1/12 border px-2 py-2 text-center">
-              {#if loadingChecks[val.dst]}
-                <LoadingCircle />
-              {:else}
-              <input type="checkbox" on:click={() => toggleIgnore(val.dst)} bind:checked={ignoredChecks[val.dst]} />
-              {/if}
-            </td>
+            <th class="w-5/12 px-2 py-2">Broken Link ({sources[url].length})</th>
+            <th class="hidden md:table-cell w-2/12 px-2 py-2">Anchor Text</th>
+            <th class="w-1/12 px-2 py-2 text-right">Status</th>
+            <th class="hidden md:table-cell w-2/12 px-2 py-2 text-right">Message</th>
+            <th class="hidden md:table-cell w-1/12 px-2 py-2 text-right">Days Unfixed</th>
+            <th class="hidden md:table-cell w-1/12 px-2 py-2" title="Ignore URL in future scans" use:tooltip>Ignore</th>
           </tr>
-        {/each}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {#each sources[url] as val}
+            {#if !(isIgnoredHidden && ignoredChecks[val.dst])}
+              <tr>
+                <td class="w-5/12 border px-2 py-2 break-all">
+                  <a
+                    class="inline-block align-baseline link"
+                    target="_blank"
+                    href={val.dst}>
+                    {val.dst.length < 70 ? val.dst : val.dst.substring(0, 70) + '...'}
+                  </a>
+
+                </td>
+                <td class="hidden md:table-cell w-2/12 border px-2 py-2 break-all">{val.link || ''}</td>
+                <td class="w-1/12 border px-2 py-2 text-right">
+                  {val.statuscode || '0'}
+                </td>
+                <td class="hidden md:table-cell w-2/12 border px-2 py-2 text-right">
+                  {val.statusmsg || ''}
+                </td>
+                <td class="hidden md:table-cell w-1/12 border px-2 py-2 text-right">
+                  {formatDaysUnfixed(val.daysUnfixed)}
+                </td>
+                <td class="hidden md:table-cell w-1/12 border px-2 py-2 text-center">
+                  {#if loadingChecks[val.dst]}
+                    <LoadingCircle />
+                  {:else}
+                  <input type="checkbox" on:click={() => toggleIgnore(val)} bind:checked={ignoredChecks[val.dst]} />
+                  {/if}
+                </td>
+              </tr>
+            {/if}
+          {/each}
+        </tbody>
+      </table>
+    {/if}
   {/if}
 {/each}
 

--- a/ui/src/components/linkauditorcomponents/DetailsTable.svelte
+++ b/ui/src/components/linkauditorcomponents/DetailsTable.svelte
@@ -22,7 +22,8 @@
     filteredBuilds = builds.filter(
       x =>
         x.src.toLowerCase().includes(input) ||
-        x.dst.toLowerCase().includes(input)
+        x.dst.toLowerCase().includes(input) ||
+        x.link.toLowerCase().includes(input)
     );
   }
 

--- a/ui/src/containers/LinkReport.svelte
+++ b/ui/src/containers/LinkReport.svelte
@@ -85,7 +85,6 @@
         on:ignore={url => showIgnore(data.buildDetails.summary.url, url, $userSession$)}
         builds={data.buildDetails ? data.buildDetails.brokenLinks : []}
         {currentRoute}
-        unscannableLinks={[]}
         scanUrl={data.buildDetails.summary.url}
       />
     </BuildDetailsSlot>

--- a/ui/src/global.scss
+++ b/ui/src/global.scss
@@ -6,6 +6,7 @@
 @import '../node_modules/@fortawesome/fontawesome-free/scss/fontawesome.scss';
 @import '../node_modules/@fortawesome/fontawesome-free/scss/solid.scss';
 @import '../node_modules/@fortawesome/fontawesome-free/scss/brands.scss';
+@import '../node_modules/@fortawesome/fontawesome-free/scss/regular.scss';
 
 html,
 body {


### PR DESCRIPTION
#806 

First part of adding filtering to the scan results page.

Adds a basic text filter that filters on source URL, destination URL and anchor text. Also adds a button to allow hiding of URLs set to ignore.