### PR TITLE
Renamed User Agent and Added default maxthread to Go

### DIFF
--- a/docker/sswlinkauditor.go
+++ b/docker/sswlinkauditor.go
@@ -336,6 +336,9 @@ func main() {
 			allUrls[status.url] = status
 		}
 
+		// Pause for 3 milliseconds before each job completes
+		time.Sleep(3 * time.Millisecond)
+
 	}
 
 	elapse := time.Since(start)

--- a/docker/sswlinkauditor.go
+++ b/docker/sswlinkauditor.go
@@ -64,7 +64,7 @@ func getClient() *http.Client {
 
 func addClientHeaders(r *http.Request) {
 	if r != nil {
-		r.Header.Add("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36")
+		r.Header.Add("User-Agent", "Mozilla/5.0 (compatible; SSWCodeAuditor; +https://codeauditor.com/)")
 		r.Header.Set("Cache-Control", "no-cache")
 		r.Header.Set("Connection", "keep-alive")
 		r.Header.Set("Accept-Encoding", "*")

--- a/docker/utils.js
+++ b/docker/utils.js
@@ -267,7 +267,7 @@ exports.runBrokenLinkCheck = (url, maxthread) => {
   try {
     const comand = maxthread
       ? `./sswlinkauditor ${url} ${maxthread}`
-      : `./sswlinkauditor ${url}`;
+      : `./sswlinkauditor ${url} 100`; // Default maxthread to 100 (Golang default is 10000) 
     return [execSync(comand, { maxBuffer: 20000 * 1024 }).toString(), null];
   } catch (error) {
     return [null, error.message];


### PR DESCRIPTION
https://github.com/SSWConsulting/SSW.CodeAuditor/issues/886

As requested from @wicksipedia 

- Renamed user agent to easier identify CodeAuditor 
  - Following best naming practice for Crawler (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent)
- Added default maxthread to Go for throttling
- Added 3ms pause after each thread finishes