### PR TITLE
♻️ Website | Update YouTube link to point to CodeAuditor's channel

### DIFF
--- a/ui/src/containers/Layout.svelte
+++ b/ui/src/containers/Layout.svelte
@@ -230,7 +230,7 @@
             <a
               class="footer-link"
               target="_blank"
-              href="https://www.youtube.com/user/sswtechtalks"
+              href="https://www.youtube.com/@codeauditor"
               title="SSW on YouTube"
             >
               <svg


### PR DESCRIPTION
As per my conversation with @adamcogan, the Youtube link on the CodeAuditor website should be updated to link to CodeAuditor's channel.

This is a small change to update the link.