### PR TITLE
✨ UI - Show number of enabled/disabled rules on scan list

### DIFF
--- a/api/functions/index.js
+++ b/api/functions/index.js
@@ -213,6 +213,7 @@ app.post('/scanresult/:api/:buildId', async (req, res) => {
 		whiteListed,
 		cloc,
 		code,
+		selectedHtmlHintRules,
 		htmlIssuesSummary,
 		htmlIssues,
 		isPrivate,
@@ -283,6 +284,7 @@ app.post('/scanresult/:api/:buildId', async (req, res) => {
 		htmlErrors: htmlErrors ? htmlErrors : 0,
 		codeIssues: getCodeErrorSummary(code),
 		htmlIssuesList,
+		selectedHtmlHintRules,
 		isPrivate,
 		finalEval,
 		buildVersion

--- a/docker/utils.js
+++ b/docker/utils.js
@@ -466,12 +466,13 @@ exports.runHtmlHint = async (startUrl, scannedUrls, writeLog, tokenApi) => {
   );
 
   if (result) {
-    result = this.handleNoFavIcon(result[0])
+    result = this.handleNoFavIcon(result[0]);
+    const selectedRules = rules?.selectedRules ?? Object.keys(htmlHintConfig).join(",");
 
     const [summary, details] = getHtmlHintDetails(result);
     writeLog("summary of html issues found", summary);
     writeLog("details of html issues", JSON.stringify(details, null, 2));
-    return [summary, details];
+    return [summary, details, selectedRules];
   }
 };
 

--- a/ui/src/components/summaryitemcomponents/CodeSummary.svelte
+++ b/ui/src/components/summaryitemcomponents/CodeSummary.svelte
@@ -32,6 +32,17 @@
     </div>
   {/if}
 
+  {#if codeSummary.selectedHtmlHintRulesCount}
+    <div class="col-span-1">
+      <span class="block whitespace-nowrap font-sans">Rules</span>
+      <span
+        class="font-sans font-bold block lg:inline-block"
+        title="Number of rules enabled">
+        {codeSummary.selectedHtmlHintRulesCount} / {codeSummary.totalHtmlHintRulesCount}
+      </span>
+    </div>
+  {/if}
+
   {#if codeSummary.htmlWarnings !== null || codeSummary.htmlErrors !== null}
   <div class="col-span-1">
     <span class="block whitespace-nowrap font-sans">

--- a/ui/src/components/summaryitemcomponents/DetailsCard.svelte
+++ b/ui/src/components/summaryitemcomponents/DetailsCard.svelte
@@ -123,7 +123,7 @@
       {#if htmlRules?.selectedRules}
         <div class="mb-2">
           <span class="cursor-pointer" on:click={handleClick} on:keydown={handleClick}>
-            <p class="inline">HTML Rules Scanned: {htmlRules.selectedRules.split(/[,]+/).length} / {totalRulesCount}</p>
+            <p class="inline">HTML Rules Scanned: {enabledRules.length} / {totalRulesCount}</p>
             <span type="button" class="inline" >
             {#if isCollapsedRules}
               <i class="fas fa-angle-up"></i>

--- a/ui/src/utils/utils.js
+++ b/ui/src/utils/utils.js
@@ -232,6 +232,19 @@ export const getCodeSummary = (value) => {
         "HTML Issues:\n" + getHtmlIssuesDescriptions(value.htmlIssuesList),
     };
   }
+
+  if (value.selectedHtmlHintRules) {
+    const selectedRules = value.selectedHtmlHintRules.split(",");
+    const selectedCount = selectedRules.filter((rule) => htmlHintRules.find(x => x.rule === rule) || customHtmlHintRules.find(x => x.rule === rule)).length;
+    const totalRulesCount = htmlHintRules.length + customHtmlHintRules.length;
+
+    summary = {
+      ...summary,
+      selectedHtmlHintRulesCount: selectedCount,
+      totalHtmlHintRulesCount: totalRulesCount,
+    };
+  }
+
   return summary;
 };
 export const HTMLERRORS = [


### PR DESCRIPTION
Closes #897 

Saves the enabled rules against a scan so that we can display that info in the scan list.

![Screenshot 2024-06-07 at 4 39 53 PM](https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/a579218e-5d21-4f01-8aab-82b9eb5d6685)

**Figure: Scan list now shows the total number of rules enabled**