### PR TITLE
🐛 Mobile | Fix issue with k6 not running in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,6 +39,9 @@ RUN wget -q https://dl.k6.io/key.gpg -O- | apt-key add -
 RUN echo "deb https://dl.k6.io/deb stable main" | tee -a /etc/apt/sources.list
 RUN apt-get update && apt-get install -y k6
 
+# copy k6 scripts
+COPY k6-scripts /home/lhci/app/k6-scripts
+
 # main nodejs app
 COPY --from=nodeBuilder /usr/src/app /home/lhci/app
 

--- a/docker/utils.js
+++ b/docker/utils.js
@@ -318,8 +318,8 @@ exports.runK6LoadTest = (url, writeLog) => {
 }
 
 /**
- * parse Lighthouse Report
- * @param {string} folder - lhr file
+ * parse k6 Report
+ * @param {string} folder - k6 file
  * @param {func} writeLog - logging method
  */
 exports.readK6Results = async (folder, writeLog) => {

--- a/ui/src/containers/K6Report.svelte
+++ b/ui/src/containers/K6Report.svelte
@@ -16,13 +16,15 @@
   let promise = getBuildDetails(currentRoute.namedParams.id);
   let userNotLoginToast;
 
+  const reportUrl = `${CONSTS.BlobURL}/k6report/${currentRoute.namedParams.id}.json`;
+
   const download = () => {
-    window.location.href = `${CONSTS.BlobURL}/atr/${currentRoute.namedParams.run}.json`;
+    window.location.href = reportUrl;
   };
 
   let k6Result = {};
-  const getK6Result = async (path) => {
-    await fetch(`${CONSTS.BlobURL}/k6report/${path}.json`)
+  const getK6Result = async () => {
+    await fetch(reportUrl)
       .then((x) => x.json())
       .then((res) => {
         k6Result = res;
@@ -30,7 +32,7 @@
     return k6Result;
   };
 
-  let getK6Data = getK6Result(currentRoute.namedParams.id);
+  let getK6Data = getK6Result();
 </script>
 
 <div class="container mx-auto">


### PR DESCRIPTION
Closes #915 

k6 isn't running from the Docker image as the k6-scripts folder never gets copied and so is never able to execute the script file. This fixes it by copying the k6-scripts folder.

Also fixes the download button not working on the k6 page.

<img width="781" alt="341270002-d45b9f0f-e519-49fc-84ff-90e32602cae3" src="https://github.com/SSWConsulting/SSW.CodeAuditor/assets/11418832/d2e0a780-9989-4aa8-992f-a2c84bb2a75a">

**✅ Figure: k6 now runs successfully**